### PR TITLE
chore(deps): bump mpp-go adapter to v0.1.1

### DIFF
--- a/conformance/adapters/go/go.mod
+++ b/conformance/adapters/go/go.mod
@@ -2,4 +2,4 @@ module mpp-conformance-adapter-go
 
 go 1.26
 
-require github.com/tempoxyz/mpp-go v0.1.0
+require github.com/tempoxyz/mpp-go v0.1.1

--- a/conformance/adapters/go/go.sum
+++ b/conformance/adapters/go/go.sum
@@ -1,2 +1,2 @@
-github.com/tempoxyz/mpp-go v0.1.0 h1:sZQLtAyym0mFOjTyYjlNTMotzMJpEHp76rEWzL9DbsU=
-github.com/tempoxyz/mpp-go v0.1.0/go.mod h1:W8wOYluVGYqIjh53CEmpPAT/M+mHVcD4/qub1zW4E/I=
+github.com/tempoxyz/mpp-go v0.1.1 h1:B2va2eavUuJFTj0x8JUgQYFXZs5iyUxh0o6MUEiA7uc=
+github.com/tempoxyz/mpp-go v0.1.1/go.mod h1:56C5E6sGkSG+Ae83Ffs5aunFitRDnohluriR8vk3q1s=


### PR DESCRIPTION
## Summary

- Bumps the Go conformance adapter from `github.com/tempoxyz/mpp-go v0.1.0` to `v0.1.1`.
- Updates `go.sum` for the released module checksums.
- Confirmed locally that Go vector conformance passes 104/104 and Go flow conformance passes 29/29.