### PR TITLE
test: add HTML-sensitive challenge ID vector

### DIFF
--- a/conformance/adapters/go/main.go
+++ b/conformance/adapters/go/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -434,11 +435,14 @@ func formatReceiptTimestamp(timestamp time.Time) string {
 }
 
 func encodeJSONBase64URL(data map[string]any) (string, error) {
-	encoded, err := json.Marshal(data)
-	if err != nil {
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(data); err != nil {
 		return "", err
 	}
-	return base64.RawURLEncoding.EncodeToString(encoded), nil
+	encoded := strings.TrimSuffix(buffer.String(), "\n")
+	return base64.RawURLEncoding.EncodeToString([]byte(encoded)), nil
 }
 
 func stringField(data map[string]any, key string) string {

--- a/conformance/vectors/challenge-id.json
+++ b/conformance/vectors/challenge-id.json
@@ -189,6 +189,28 @@
       "expected": "TqujwpuDDg_zsWGINAd5XObO2rRe6uYufpqvtDmr6N8"
     },
     {
+      "name": "html_sensitive_request_canonicalization",
+      "description": "HMAC input preserves HTML-sensitive JSON string characters without escaping them",
+      "tags": [
+        "happy-path",
+        "cross-sdk-validated",
+        "canonicalization"
+      ],
+      "input": {
+        "secretKey": "test-vector-secret",
+        "realm": "api.example.com",
+        "method": "tempo",
+        "intent": "charge",
+        "request": {
+          "amount": "1500",
+          "currency": "USD",
+          "description": "Access <premium> & analytics",
+          "recipient": "merchant"
+        }
+      },
+      "expected": "9wuIbToTGnzxJuu715tZMeGH5MS0xVO6FgpFLBXqWCY"
+    },
+    {
       "name": "resource_path_query_binding",
       "description": "Route and query resource discriminator is part of the HMAC input",
       "tags": [


### PR DESCRIPTION
## Summary

- Adds a challenge ID vector with `<`, `>`, and `&` inside HMAC-bound request JSON so adapters must preserve HTML-sensitive characters during canonicalization.
- Updates the Go conformance adapter's local challenge-id helper to disable HTML escaping, matching the released mpp-go behavior.
- Local checks: Go vectors passed 105/105; full vector run passed for Go, Python, Rust, and TypeScript, with local Java/Ruby adapter builds blocked by missing Java runtime and Bundler 4.0.9.