### PR TITLE
chore(deps): bump python and rust conformance adapters

### DIFF
--- a/conformance/adapters/python/pyproject.toml
+++ b/conformance/adapters/python/pyproject.toml
@@ -5,5 +5,5 @@ description = "Python conformance adapter for MPP tooling"
 license = { text = "MIT" }
 requires-python = ">=3.12"
 dependencies = [
-    "pympp==0.8.1",
+    "pympp==0.8.2",
 ]

--- a/conformance/adapters/python/uv.lock
+++ b/conformance/adapters/python/uv.lock
@@ -79,18 +79,18 @@ dependencies = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pympp", specifier = "==0.8.1" }]
+requires-dist = [{ name = "pympp", specifier = "==0.8.2" }]
 
 [[package]]
 name = "pympp"
-version = "0.8.1"
+version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/f1/ab49e523734add0f0e29d21ef77206fa987dd2bf098a5586aa567bd29ca9/pympp-0.8.1.tar.gz", hash = "sha256:663d05d0bea4c082e44edb5122c8efe7630d13999edee0534f606a8d9dd58db4", size = 146914, upload-time = "2026-06-01T16:50:52.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/51/6cf407f24ad3e798e4730e502b65d01083dfcb69b968640544aa2ac18803/pympp-0.8.2.tar.gz", hash = "sha256:be6f9eeb52f1688d934cafbb57d0cc1e2afd7dd02bbc09d38b03f21e2fb59a5c", size = 148171, upload-time = "2026-06-02T07:42:51.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/f5/c6c8c8d98cd6fc6211eb7aa63a36bc5ee6ae3bb97bec406baad60c00417f/pympp-0.8.1-py3-none-any.whl", hash = "sha256:191c0e3e0bd2ce0cab548dc9cf31a1300faf8ba34bac81c3c2bf08e70ae279d9", size = 87023, upload-time = "2026-06-01T16:50:51.358Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a6/9ed89bb93d80b79963e243e1bcf7831e3d92eeaf467cf904ec22493a6c8f/pympp-0.8.2-py3-none-any.whl", hash = "sha256:df28393460ffe8f9971e89ebf43e40e452c1dc648aba2fe86fa355c3858e7256", size = 87584, upload-time = "2026-06-02T07:42:50.598Z" },
 ]
 
 [[package]]

--- a/conformance/adapters/rust/Cargo.lock
+++ b/conformance/adapters/rust/Cargo.lock
@@ -646,9 +646,9 @@ dependencies = [
 
 [[package]]
 name = "mpp"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "019fe17dda01228c29e716e73cb099ca5eb35acae3de5bbd01dd624b3ed26076"
+checksum = "30e72c53d545bed570868bcbb47a6aa8fecf2547fe7f678b154acf60ec1e3913"
 dependencies = [
  "base64",
  "hmac",

--- a/conformance/adapters/rust/Cargo.toml
+++ b/conformance/adapters/rust/Cargo.toml
@@ -9,7 +9,7 @@ name = "adapter"
 path = "src/main.rs"
 
 [dependencies]
-mpp = { version = "=0.10.3" }
+mpp = { version = "=0.10.4" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 hmac = "0.13"


### PR DESCRIPTION
## Summary
- Bump the Python conformance adapter to `pympp==0.8.2`.
- Bump the Rust conformance adapter to `mpp = "=0.10.4"`.
- Confirmed Python and Rust vector/flow conformance pass locally.