### PR TITLE
ci: build typescript sdk for conformance

### DIFF
--- a/.github/workflows/sdk-conformance.yml
+++ b/.github/workflows/sdk-conformance.yml
@@ -82,6 +82,14 @@ jobs:
         env:
           ADAPTER: ${{ steps.resolve.outputs.adapter }}
 
+      - name: Build TypeScript SDK checkout
+        if: steps.resolve.outputs.adapter == 'typescript'
+        working-directory: sdk
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile
+          pnpm build
+
       - name: Install adapter dependencies
         run: |
           case "$ADAPTER" in


### PR DESCRIPTION
## Summary

- Builds the TypeScript SDK checkout before installing the conformance adapter dependency.
- Fixes clean SDK checkout runs where local `mppx` resolves to generated `dist/index.js`.
- Checked against a clean `mppx` checkout: TypeScript vectors passed 105/105 and flows passed 29/29.
