### PR TITLE
ci: bump conformance node runtime

### DIFF
--- a/.github/actions/setup-conformance/action.yml
+++ b/.github/actions/setup-conformance/action.yml
@@ -32,7 +32,7 @@ runs:
       if: inputs.setup-node == 'true' || inputs.adapter == 'typescript' || inputs.adapter == 'all'
       uses: actions/setup-node@v6
       with:
-        node-version: "20"
+        node-version: "24.5"
         cache: npm
         cache-dependency-path: ${{ inputs.conformance-directory }}/package-lock.json
 


### PR DESCRIPTION
## Summary

- Bumps the shared conformance Node runtime from 20 to 24.5.
- Matches the mppx CI runtime so TypeScript SDK checkout builds can use current Node built-ins like `node:sqlite`.
