### PR TITLE
chore: bump mppx conformance adapter

### DIFF
--- a/conformance/package-lock.json
+++ b/conformance/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "mppx": "0.6.28"
+        "mppx": "0.6.29"
       },
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -717,13 +717,13 @@
       }
     },
     "node_modules/mppx": {
-      "version": "0.6.28",
-      "resolved": "https://registry.npmjs.org/mppx/-/mppx-0.6.28.tgz",
-      "integrity": "sha512-R39xdhjBlcUBFaNCooyvYCE0iRTS6yhbZyFTZO88PPb9TFdQGLMdowevltkjeRsVAP/hRf9PGbsEUcOcFFOuwA==",
+      "version": "0.6.29",
+      "resolved": "https://registry.npmjs.org/mppx/-/mppx-0.6.29.tgz",
+      "integrity": "sha512-Qi/F/fZV0WZyklm2pY1ipAt+zQQsHuuA7DBhsvrHxxQAAZmWIVWmIujc7ebqawiOqlkuR2SQ3VOs7TqZYFiQxA==",
       "license": "MIT",
       "dependencies": {
         "incur": "^0.4.5",
-        "ox": "0.14.22",
+        "ox": "0.14.24",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -735,7 +735,7 @@
         "elysia": ">=1",
         "express": ">=5",
         "hono": ">=4.12.18",
-        "viem": ">=2.50.4"
+        "viem": ">=2.51.0"
       },
       "peerDependenciesMeta": {
         "@modelcontextprotocol/sdk": {
@@ -753,9 +753,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.22",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.22.tgz",
-      "integrity": "sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==",
+      "version": "0.14.24",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.24.tgz",
+      "integrity": "sha512-mviaFeN/cSkj/1B7EJKB3fYzQ4E3y7CDmR7Iqei1QUT0M1Zkuo0kNI/ewBnShf7h5r57gp68/DFltjNu5HJCYQ==",
       "funding": [
         {
           "type": "github",
@@ -829,9 +829,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.50.4",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.50.4.tgz",
-      "integrity": "sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.0.tgz",
+      "integrity": "sha512-py2QPYe9e1f4DmPJCsXF7zHmyZ0PkJrBxdQZ5dvNXvzy3UzWkUn7dNfC0TMeNm6Qv1tKw3b6qXXExpx6L0oMbw==",
       "funding": [
         {
           "type": "github",
@@ -847,7 +847,7 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.22",
+        "ox": "0.14.27",
         "ws": "8.20.1"
       },
       "peerDependencies": {
@@ -877,6 +877,37 @@
           "optional": true
         },
         "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.27.tgz",
+      "integrity": "sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -17,7 +17,7 @@
     "build:all": "make install"
   },
   "dependencies": {
-    "mppx": "0.6.28"
+    "mppx": "0.6.29"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",


### PR DESCRIPTION
## Summary

- Bumps the TypeScript conformance adapter from `mppx@0.6.28` to `mppx@0.6.29`.
- Updates the npm lockfile for the new published adapter dependency graph.
- Checked TypeScript conformance locally: vectors passed 105/105 and flows passed 29/29.
