### PR TITLE
ci: allow existing conformance coverage

### DIFF
--- a/.github/workflows/sdk-conformance-policy.yml
+++ b/.github/workflows/sdk-conformance-policy.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: conformance-not-needed
+      require-conformance-reference:
+        description: Whether protocol-sensitive SDK PRs must reference a conformance PR instead of falling back to the default conformance ref.
+        required: false
+        type: boolean
+        default: false
       conformance-paths:
         description: Newline-separated mpp-tools path globs that count as conformance coverage in a referenced Conformance-PR.
         required: false
@@ -77,13 +82,15 @@ jobs:
           PROTOCOL_PATHS: ${{ inputs.protocol-paths }}
           DEFAULT_CONFORMANCE_REF: ${{ inputs.default-conformance-ref }}
           SKIP_LABEL: ${{ inputs.skip-label }}
+          REQUIRE_CONFORMANCE_REFERENCE: ${{ inputs.require-conformance-reference }}
         run: |
           python3 mpp-tools/conformance/scripts/check_conformance_policy.py \
             --event-path "$GITHUB_EVENT_PATH" \
             --changed-files changed-files.txt \
             --protocol-paths "$PROTOCOL_PATHS" \
             --default-conformance-ref "$DEFAULT_CONFORMANCE_REF" \
-            --skip-label "$SKIP_LABEL"
+            --skip-label "$SKIP_LABEL" \
+            --require-reference "$REQUIRE_CONFORMANCE_REFERENCE"
 
       - name: Validate referenced conformance PR
         if: steps.policy.outputs.conformance_pr != ''

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -193,9 +193,12 @@ Then make the called `conformance` job a required branch-protection or ruleset
 check in the SDK repository.
 
 For protocol-sensitive SDK paths, add the policy gate before the behavior gate.
-The policy gate fails PRs that change those paths unless the PR body references
-an open or merged conformance PR, or a maintainer applies the
-`conformance-not-needed` label.
+When those paths change, the policy gate chooses the conformance ref used by
+the behavior gate. By default it uses `mpp-tools` `main`, which lets SDK PRs pass
+when existing conformance coverage already exercises the behavior. If new
+coverage is still pending in `mpp-tools`, reference that conformance PR in the
+SDK PR body. Maintainers can apply the `conformance-not-needed` label when a
+protocol-sensitive SDK change intentionally does not need conformance coverage.
 Include the `edited`, `labeled`, and `unlabeled` pull request event types so
 updates to those fields rerun the policy check.
 
@@ -216,7 +219,8 @@ jobs:
       conformance-ref: ${{ needs.conformance-policy.outputs.conformance_ref }}
 ```
 
-When a PR changes one of those paths, include this in the PR body:
+When a PR needs pending conformance coverage that has not landed on
+`mpp-tools` `main`, include this in the PR body:
 
 ```text
 Conformance-PR: tempoxyz/mpp-tools#123
@@ -228,6 +232,10 @@ against `refs/pull/<number>/head` for that conformance PR. By default the
 coverage paths are
 `conformance/vectors/**`, `conformance/flows/**`, `conformance/schemas/**`, and
 `conformance/operations.json`.
+
+Set `require-conformance-reference: true` if an SDK repository wants to keep the
+stricter policy where every protocol-sensitive PR must reference a conformance
+PR or carry the skip label.
 
 To run the same mode locally:
 

--- a/conformance/scripts/check_conformance_policy.py
+++ b/conformance/scripts/check_conformance_policy.py
@@ -106,7 +106,17 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--protocol-paths", required=True)
     parser.add_argument("--default-conformance-ref", default="main")
     parser.add_argument("--skip-label", default="conformance-not-needed")
+    parser.add_argument("--require-reference", default="false")
     return parser.parse_args()
+
+
+def parse_bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off", ""}:
+        return False
+    raise ValueError(f"invalid boolean value {value!r}")
 
 
 def main() -> int:
@@ -115,6 +125,10 @@ def main() -> int:
     pr = pull_request(event)
     default_ref = args.default_conformance_ref
     patterns = split_patterns(args.protocol_paths)
+    try:
+        require_reference = parse_bool(args.require_reference)
+    except ValueError as exc:
+        return fail(str(exc), {"reason": "Invalid require-reference value."})
 
     base_outputs = {
         "conformance_ref": default_ref,
@@ -164,6 +178,12 @@ def main() -> int:
         ref = f"refs/pull/{number}/head"
         reason = f"Using mpp-tools PR #{number} as conformance ref."
         output({**policy_outputs, "conformance_ref": ref, "conformance_pr": number, "reason": reason})
+        print(reason)
+        return 0
+
+    if not require_reference:
+        reason = f"No Conformance-PR referenced; using default conformance ref {default_ref!r} so existing coverage must pass."
+        output({**policy_outputs, "reason": reason})
         print(reason)
         return 0
 

--- a/conformance/scripts/test_check_conformance_policy.py
+++ b/conformance/scripts/test_check_conformance_policy.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Tests for SDK conformance policy checks."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("check_conformance_policy.py")
+
+
+class CheckConformancePolicyTest(unittest.TestCase):
+    def run_policy(
+        self,
+        *,
+        body: str = "",
+        labels: list[str] | None = None,
+        changed_files: list[str] | None = None,
+        require_reference: str = "false",
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        labels = labels or []
+        changed_files = changed_files or ["pkg/mpp/parse.go"]
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            event_path = tmp_path / "event.json"
+            files_path = tmp_path / "changed-files.txt"
+            output_path = tmp_path / "github-output.txt"
+
+            event_path.write_text(
+                json.dumps(
+                    {
+                        "pull_request": {
+                            "body": body,
+                            "labels": [{"name": name} for name in labels],
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            files_path.write_text("\n".join(changed_files), encoding="utf-8")
+
+            env = os.environ.copy()
+            env["GITHUB_OUTPUT"] = str(output_path)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--event-path",
+                    str(event_path),
+                    "--changed-files",
+                    str(files_path),
+                    "--protocol-paths",
+                    "pkg/**",
+                    "--require-reference",
+                    require_reference,
+                ],
+                check=False,
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+            outputs = output_path.read_text(encoding="utf-8") if output_path.exists() else ""
+            return result, outputs
+
+    def test_protocol_change_uses_default_conformance_ref_without_reference(self) -> None:
+        result, outputs = self.run_policy()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("using default conformance ref 'main'", result.stdout)
+        self.assertIn("conformance_ref=main", outputs)
+        self.assertIn("protocol_changed=true", outputs)
+
+    def test_protocol_change_can_require_reference(self) -> None:
+        result, outputs = self.run_policy(require_reference="true")
+
+        self.assertEqual(result.returncode, 1, result.stdout)
+        self.assertIn("does not reference conformance coverage", result.stderr)
+        self.assertIn("Conformance-PR: tempoxyz/mpp-tools#123", result.stderr)
+        self.assertIn("protocol_changed=true", outputs)
+
+    def test_conformance_pr_overrides_default_ref(self) -> None:
+        result, outputs = self.run_policy(body="Conformance-PR: tempoxyz/mpp-tools#123")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Using mpp-tools PR #123 as conformance ref.", result.stdout)
+        self.assertIn("conformance_ref=refs/pull/123/head", outputs)
+        self.assertIn("conformance_pr=123", outputs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Allow SDK conformance policy to fall back to the default mpp-tools ref when no Conformance-PR is referenced.
- Keep strict reference enforcement available with `require-conformance-reference: true`.
- Document the existing-coverage path and add policy unit tests.