### PR TITLE
chore: bump mpp-go adapter to v0.1.2

### DIFF
--- a/conformance/adapters/go/go.mod
+++ b/conformance/adapters/go/go.mod
@@ -2,4 +2,4 @@ module mpp-conformance-adapter-go
 
 go 1.26
 
-require github.com/tempoxyz/mpp-go v0.1.1
+require github.com/tempoxyz/mpp-go v0.1.2

--- a/conformance/adapters/go/go.sum
+++ b/conformance/adapters/go/go.sum
@@ -1,2 +1,10 @@
-github.com/tempoxyz/mpp-go v0.1.1 h1:B2va2eavUuJFTj0x8JUgQYFXZs5iyUxh0o6MUEiA7uc=
-github.com/tempoxyz/mpp-go v0.1.1/go.mod h1:56C5E6sGkSG+Ae83Ffs5aunFitRDnohluriR8vk3q1s=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tempoxyz/mpp-go v0.1.2 h1:8Yo95CntHynHvBMco/Eub7unISBC1TGe3Ku0tAOjUOM=
+github.com/tempoxyz/mpp-go v0.1.2/go.mod h1:tVrbCg1lo8PUk5+RU1VsRB4KBP+EFf83dBhiD0iclI8=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

- Bump the Go conformance adapter from `github.com/tempoxyz/mpp-go v0.1.1` to `v0.1.2`.
- Refresh the adapter `go.sum` for the released module version.

Checked locally with `go test ./...`, Go vector conformance, and Go flow conformance.