### PR TITLE
Add Tempo proof conformance vector

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -44,6 +44,7 @@ Vectors live in `vectors/` and cover the core protocol surface:
 | `receipt.json` | Parsing and formatting `Payment-Receipt: ...` headers. Base64url-encoded JSON with `status`, `method`, `timestamp`, `reference`. |
 | `base64url.json` | RFC 4648 §5 encoding: no padding, URL-safe alphabet (`-`/`_` instead of `+`/`/`). |
 | `challenge-id.json` | Deterministic challenge ID generation via HMAC-SHA256. Input is pipe-delimited (`realm\|method\|intent\|canonicalized_request\|expires\|digest\|opaque`), output is unpadded base64url. |
+| `tempo-proof.json` | EIP-712 typed-data shape for zero-amount Tempo proof credentials. Binds `challengeId` and `realm` under domain `MPP` version `2`. |
 
 Each vector file contains **scenarios** — individual test cases with a name, description, tags, and expected inputs/outputs:
 

--- a/conformance/adapters/python/adapter.json
+++ b/conformance/adapters/python/adapter.json
@@ -23,6 +23,7 @@
     "base64url.encode",
     "base64url.decode",
     "challenge.id",
-    "tempo.receipt.verify"
+    "tempo.receipt.verify",
+    "tempo.proof.typed_data"
   ]
 }

--- a/conformance/adapters/python/adapter.py
+++ b/conformance/adapters/python/adapter.py
@@ -69,6 +69,27 @@ def generate_conformance_challenge_id(*, secret_key: str, realm: str, method: st
     return base64.urlsafe_b64encode(signature).decode("ascii").rstrip("=")
 
 
+def tempo_proof_typed_data(*, chain_id: int, challenge_id: str, realm: str):
+    return {
+        "domain": {
+            "name": "MPP",
+            "version": "2",
+            "chainId": chain_id,
+        },
+        "types": {
+            "Proof": [
+                {"name": "challengeId", "type": "string"},
+                {"name": "realm", "type": "string"},
+            ],
+        },
+        "primaryType": "Proof",
+        "message": {
+            "challengeId": challenge_id,
+            "realm": realm,
+        },
+    }
+
+
 def challenge_to_dict(challenge: Challenge) -> dict:
     """Convert a Challenge to a JSON-serializable dict."""
     result = {
@@ -157,6 +178,7 @@ OP_TO_COMMAND = {
     "base64url.decode": "base64url-decode",
     "challenge.id": "generate-challenge-id",
     "tempo.receipt.verify": "verify-tempo-receipt",
+    "tempo.proof.typed_data": "tempo-proof-typed-data",
 }
 
 
@@ -361,6 +383,14 @@ def main():
         elif command == "verify-tempo-receipt":
             params = json.loads(input_data)
             print(json.dumps(asyncio.run(verify_tempo_receipt(params))))
+        elif command == "tempo-proof-typed-data":
+            params = json.loads(input_data)
+            result = tempo_proof_typed_data(
+                chain_id=params["chainId"],
+                challenge_id=params["challengeId"],
+                realm=params["realm"],
+            )
+            print(json.dumps(success(result)))
         else:
             print(json.dumps(error(f"Unknown command: {command}")))
     except Exception as e:

--- a/conformance/adapters/rust/adapter.json
+++ b/conformance/adapters/rust/adapter.json
@@ -22,6 +22,7 @@
     "receipt.format",
     "base64url.encode",
     "base64url.decode",
-    "challenge.id"
+    "challenge.id",
+    "tempo.proof.typed_data"
   ]
 }

--- a/conformance/adapters/rust/src/main.rs
+++ b/conformance/adapters/rust/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
         "base64url-encode" => handle_base64url_encode(input),
         "base64url-decode" => handle_base64url_decode(input),
         "generate-challenge-id" => handle_generate_challenge_id(input),
+        "tempo-proof-typed-data" => handle_tempo_proof_typed_data(input),
         _ => print_error(&format!("Unknown command: {}", command), "unknown_error"),
     }
 }
@@ -353,6 +354,35 @@ fn handle_generate_challenge_id(input: &str) {
     }
 }
 
+fn handle_tempo_proof_typed_data(input: &str) {
+    match serde_json::from_str::<serde_json::Value>(input) {
+        Ok(params) => {
+            let chain_id = params.get("chainId").and_then(|v| v.as_u64()).unwrap_or(0);
+            let challenge_id = str_field(&params, "challengeId");
+            let realm = str_field(&params, "realm");
+            print_success(json!({
+                "domain": {
+                    "name": "MPP",
+                    "version": "2",
+                    "chainId": chain_id,
+                },
+                "types": {
+                    "Proof": [
+                        { "name": "challengeId", "type": "string" },
+                        { "name": "realm", "type": "string" },
+                    ],
+                },
+                "primaryType": "Proof",
+                "message": {
+                    "challengeId": challenge_id,
+                    "realm": realm,
+                },
+            }));
+        }
+        Err(e) => print_error(&e.to_string(), "generation_error"),
+    }
+}
+
 fn print_adapter_success<T: serde::Serialize>(value: T) {
     println!(
         "{}",
@@ -416,6 +446,7 @@ fn legacy_command_for_operation(op: &str) -> Option<&'static str> {
         "base64url.encode" => Some("base64url-encode"),
         "base64url.decode" => Some("base64url-decode"),
         "challenge.id" => Some("generate-challenge-id"),
+        "tempo.proof.typed_data" => Some("tempo-proof-typed-data"),
         _ => None,
     }
 }

--- a/conformance/adapters/typescript/adapter.json
+++ b/conformance/adapters/typescript/adapter.json
@@ -20,6 +20,7 @@
     "base64url.decode",
     "challenge.id",
     "http.payment_request",
-    "stripe.external_id_binding"
+    "stripe.external_id_binding",
+    "tempo.proof.typed_data"
   ]
 }

--- a/conformance/golden/adapter.ts
+++ b/conformance/golden/adapter.ts
@@ -218,6 +218,31 @@ async function verifyStripeExternalIdBinding(input: {
 	}
 }
 
+function tempoProofTypedData(params: {
+	chainId: number
+	challengeId: string
+	realm: string
+}) {
+	return {
+		domain: {
+			name: 'MPP',
+			version: '2',
+			chainId: params.chainId,
+		},
+		types: {
+			Proof: [
+				{ name: 'challengeId', type: 'string' },
+				{ name: 'realm', type: 'string' },
+			],
+		},
+		primaryType: 'Proof',
+		message: {
+			challengeId: params.challengeId,
+			realm: params.realm,
+		},
+	}
+}
+
 function hasDuplicateChallengeParameter(header: string): boolean {
 	const seen = new Set<string>()
 	for (const match of header.matchAll(/(?:^|,\s*)(\w+)=/g)) {
@@ -290,6 +315,11 @@ async function runCommand(command: string, input: string): Promise<Result<unknow
 				return success(await verifyStripeExternalIdBinding(params))
 			}
 
+			case 'tempo-proof-typed-data': {
+				const params = JSON.parse(input)
+				return success(tempoProofTypedData(params))
+			}
+
 			default:
 				return error(`Unknown command: ${command}`, 'unknown_error')
 		}
@@ -323,6 +353,7 @@ const OP_TO_COMMAND: Record<string, string> = {
 	'base64url.decode': 'base64url-decode',
 	'challenge.id': 'generate-challenge-id',
 	'stripe.external_id_binding': 'verify-stripe-external-id-binding',
+	'tempo.proof.typed_data': 'tempo-proof-typed-data',
 }
 
 function commandInputForRequest(op: string, input: unknown): string {

--- a/conformance/operations.json
+++ b/conformance/operations.json
@@ -82,6 +82,14 @@
       "comparison": "exact",
       "description": "Verify Stripe charge receipt attribution uses only the server-bound request externalId and cannot be forged from credential payload."
     },
+    "tempo.proof.typed_data": {
+      "category": "vector",
+      "inputRef": "protocol.schema.json#/$defs/TempoProofInput",
+      "successRef": "protocol.schema.json#/$defs/TempoProofTypedData",
+      "errorTypes": ["generation_error"],
+      "comparison": "exact",
+      "description": "Generate the EIP-712 typed-data shape for a zero-amount Tempo proof credential."
+    },
     "http.payment_request": {
       "category": "flow",
       "inputRef": "protocol.schema.json#/$defs/HttpPaymentRequest",

--- a/conformance/schemas/adapter-request.schema.json
+++ b/conformance/schemas/adapter-request.schema.json
@@ -61,6 +61,10 @@
       "then": { "properties": { "input": { "$ref": "protocol.schema.json#/$defs/StripeExternalIdBindingInput" } } }
     },
     {
+      "if": { "properties": { "op": { "const": "tempo.proof.typed_data" } }, "required": ["op"] },
+      "then": { "properties": { "input": { "$ref": "protocol.schema.json#/$defs/TempoProofInput" } } }
+    },
+    {
       "if": { "properties": { "op": { "const": "http.payment_request" } }, "required": ["op"] },
       "then": { "properties": { "input": { "$ref": "protocol.schema.json#/$defs/HttpPaymentRequest" } } }
     },

--- a/conformance/schemas/protocol.schema.json
+++ b/conformance/schemas/protocol.schema.json
@@ -18,6 +18,7 @@
         "server.verify",
         "tempo.fee_payer.cosign",
         "tempo.receipt.verify",
+        "tempo.proof.typed_data",
         "http.payment_request",
         "stripe.external_id_binding"
       ]
@@ -172,6 +173,44 @@
           }
         }
       ]
+    },
+    "TempoProofInput": {
+      "type": "object",
+      "required": ["chainId", "challengeId", "realm"],
+      "additionalProperties": false,
+      "properties": {
+        "chainId": { "type": "integer", "minimum": 0 },
+        "challengeId": { "type": "string", "minLength": 1 },
+        "realm": { "type": "string" }
+      }
+    },
+    "TempoProofTypedData": {
+      "type": "object",
+      "required": ["domain", "types", "primaryType", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "domain": {
+          "type": "object",
+          "required": ["name", "version", "chainId"],
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "version": { "type": "string" },
+            "chainId": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "types": { "$ref": "#/$defs/JsonObject" },
+        "primaryType": { "type": "string" },
+        "message": {
+          "type": "object",
+          "required": ["challengeId", "realm"],
+          "additionalProperties": false,
+          "properties": {
+            "challengeId": { "type": "string", "minLength": 1 },
+            "realm": { "type": "string" }
+          }
+        }
+      }
     },
     "HttpPaymentMode": {
       "type": "string",

--- a/conformance/scripts/harness.py
+++ b/conformance/scripts/harness.py
@@ -27,6 +27,7 @@ COMMAND_TO_OPERATION = {
     "base64url-decode": "base64url.decode",
     "generate-challenge-id": "challenge.id",
     "verify-stripe-external-id-binding": "stripe.external_id_binding",
+    "tempo-proof-typed-data": "tempo.proof.typed_data",
 }
 
 
@@ -133,6 +134,7 @@ def request_input_for_command(command: str, input_data: str) -> tuple[str, Any]:
         "receipt.format",
         "challenge.id",
         "stripe.external_id_binding",
+        "tempo.proof.typed_data",
     }:
         return op, json.loads(input_data)
     if op in {"base64url.encode", "base64url.decode"}:

--- a/conformance/vectors/package.json
+++ b/conformance/vectors/package.json
@@ -8,7 +8,8 @@
     "./authorization.json": "./authorization.json",
     "./receipt.json": "./receipt.json",
     "./base64url.json": "./base64url.json",
-    "./challenge-id.json": "./challenge-id.json"
+    "./challenge-id.json": "./challenge-id.json",
+    "./tempo-proof.json": "./tempo-proof.json"
   },
   "files": [
     "*.json"

--- a/conformance/vectors/tempo-proof.json
+++ b/conformance/vectors/tempo-proof.json
@@ -1,0 +1,53 @@
+{
+  "version": "2.0.0",
+  "spec_ref": "Tempo zero-amount proof credential",
+  "description": "EIP-712 typed-data shape for zero-amount Tempo proof credentials. The proof binds challengeId + realm using domain MPP v2.",
+  "commands": {
+    "operation": "tempo.proof.typed_data"
+  },
+  "scenarios": [
+    {
+      "name": "zero_amount_proof_shape",
+      "description": "Proof typed data matches mppx: domain MPP v2 and message fields challengeId + realm.",
+      "tags": [
+        "happy-path",
+        "cross-sdk-validated",
+        "tempo",
+        "proof",
+        "zero-amount"
+      ],
+      "input": {
+        "chainId": 42431,
+        "challengeId": "proof-challenge-id",
+        "realm": "api.example.com"
+      },
+      "expected": {
+        "ok": true,
+        "value": {
+          "domain": {
+            "name": "MPP",
+            "version": "2",
+            "chainId": 42431
+          },
+          "types": {
+            "Proof": [
+              {
+                "name": "challengeId",
+                "type": "string"
+              },
+              {
+                "name": "realm",
+                "type": "string"
+              }
+            ]
+          },
+          "primaryType": "Proof",
+          "message": {
+            "challengeId": "proof-challenge-id",
+            "realm": "api.example.com"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `tempo.proof.typed_data` conformance operation
- add `tempo-proof.json` vector for zero-amount proof shape
- wire Python, Rust, and TypeScript/golden adapters to emit the shape

## Verification
- `cargo fmt` in `conformance/adapters/rust`
- `uv run --with deepdiff --with jsonschema python scripts/vector_runner.py --vector tempo-proof --adapter python --verbose`
- `uv run --with deepdiff --with jsonschema python scripts/vector_runner.py --vector tempo-proof --adapter rust --verbose`
- TypeScript adapter was attempted, but this checkout is missing the `mppx` package dependency, so it failed before executing the command.

Prompted by: @brendanjryan