### PR TITLE
Add missing challenge expires conformance flow

### DIFF
--- a/conformance/flows/compliance-server.ts
+++ b/conformance/flows/compliance-server.ts
@@ -50,6 +50,7 @@ type FlowCase = {
   http_method?: string
   invalid_challenge_id?: boolean
   invalid_www_authenticate?: boolean
+  omit_challenge_expires?: boolean
   omit_receipt?: boolean
   mismatch_request?: boolean
   no_payment?: boolean

--- a/conformance/flows/flows.json
+++ b/conformance/flows/flows.json
@@ -116,6 +116,22 @@
       "invalid_challenge_id": true
     },
     {
+      "name": "missing_challenge_expires_rejected",
+      "path": "/charge/missing-challenge-expires",
+      "request": {
+        "amount": "850",
+        "currency": "USD",
+        "recipient": "merchant",
+        "expires": "2099-01-01T00:00:00Z"
+      },
+      "payload": {
+        "type": "transaction",
+        "signature": "0xmissingexpires"
+      },
+      "expected_signature": "0xmissingexpires",
+      "omit_challenge_expires": true
+    },
+    {
       "name": "no_receipt_header",
       "path": "/charge/no-receipt",
       "request": {

--- a/conformance/flows/golden-results.json
+++ b/conformance/flows/golden-results.json
@@ -231,6 +231,39 @@
       }
     },
     {
+      "name": "missing_challenge_expires_rejected",
+      "outcome": {
+        "ok": false,
+        "status": 402,
+        "error_type": "payment_required",
+        "content_type": "application/problem+json"
+      },
+      "challenge": {
+        "id": "1LBsi_ajm1XQTFwdzUegxptQnxNTA0ThYDXZ99Q8dzc",
+        "method": "tempo",
+        "intent": "charge",
+        "realm": "conformance",
+        "request": {
+          "amount": "850",
+          "currency": "USD",
+          "expires": "2099-01-01T00:00:00Z",
+          "recipient": "merchant"
+        }
+      },
+      "credential": {
+        "payload": {
+          "type": "transaction",
+          "signature": "0xmissingexpires"
+        }
+      },
+      "problem_details": {
+        "type": "https://paymentauth.org/problems/invalid-challenge",
+        "title": "Invalid Challenge",
+        "status": 402,
+        "detail": "Challenge \"1LBsi_ajm1XQTFwdzUegxptQnxNTA0ThYDXZ99Q8dzc\" is invalid: challenge was not issued by this server."
+      }
+    },
+    {
       "name": "no_receipt_header",
       "outcome": {
         "ok": true,

--- a/conformance/scripts/flow_runner.py
+++ b/conformance/scripts/flow_runner.py
@@ -341,6 +341,8 @@ def run_flow_case(
         challenge["request"] = {**request, "amount": "1"}
     if flow_case.get("invalid_challenge_id"):
         challenge["id"] = "invalid-challenge-id"
+    if flow_case.get("omit_challenge_expires"):
+        challenge.pop("expires", None)
 
     payload = flow_case.get("payload")
     credential = {"challenge": challenge, "payload": payload if payload is not None else {}}


### PR DESCRIPTION
## Summary
- add a conformance flow for credentials that omit an echoed challenge `expires` value
- teach the flow runner to remove `challenge.expires` for targeted negative cases
- update TypeScript golden results for the expected 402 invalid-challenge response

## Verification
- `uv run --with-requirements requirements.txt scripts/flow_runner.py --adapter typescript`

Prompted by: @brendanjryan