### PR TITLE
test: add parser stress vector

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -57,6 +57,8 @@ Each vector file contains **scenarios** — individual test cases with a name, d
 }
 ```
 
+Scenarios may optionally include `adapters` to restrict an edge case to specific SDK adapters, and `maxDurationMs` or `maxDurationMsByAdapter` to assert bounded execution for parser stress cases. Long stress inputs can use `wire` as `{ "prefix": "...", "repeat": "...", "count": 123, "suffix": "..." }` to keep fixtures reviewable.
+
 ### Test Types
 
 | Test | What It Checks |

--- a/conformance/adapters/rust/src/main.rs
+++ b/conformance/adapters/rust/src/main.rs
@@ -211,7 +211,7 @@ fn handle_format_www_authenticate(input: &str) {
 
             let challenge = PaymentChallenge {
                 id: str_field(&value, "id"),
-                realm: str_field(&value, "realm").into(),
+                realm: str_field(&value, "realm"),
                 method: str_field(&value, "method").into(),
                 intent: str_field(&value, "intent").into(),
                 request: request_b64,
@@ -329,16 +329,18 @@ fn handle_generate_challenge_id(input: &str) {
             let digest = opt_str_field(&params, "digest");
             let opaque = opt_str_field(&params, "opaque");
 
-            let id = match generate_conformance_challenge_id(
+            let challenge_id_params = ChallengeIdParams {
                 secret_key,
-                &realm,
-                &method,
-                &intent,
-                &request,
-                expires.as_deref(),
-                digest.as_deref(),
-                opaque.as_deref(),
-            ) {
+                realm: &realm,
+                method: &method,
+                intent: &intent,
+                request: &request,
+                expires: expires.as_deref(),
+                digest: digest.as_deref(),
+                opaque: opaque.as_deref(),
+            };
+
+            let id = match generate_conformance_challenge_id(challenge_id_params) {
                 Ok(id) => id,
                 Err(e) => {
                     print_error(&e.to_string(), "generation_error");
@@ -511,33 +513,37 @@ fn adapter_value_for_operation(op: &str, result: Value) -> Value {
     result
 }
 
+struct ChallengeIdParams<'a> {
+    secret_key: &'a str,
+    realm: &'a str,
+    method: &'a str,
+    intent: &'a str,
+    request: &'a Value,
+    expires: Option<&'a str>,
+    digest: Option<&'a str>,
+    opaque: Option<&'a str>,
+}
+
 fn generate_conformance_challenge_id(
-    secret_key: &str,
-    realm: &str,
-    method: &str,
-    intent: &str,
-    request: &Value,
-    expires: Option<&str>,
-    digest: Option<&str>,
-    opaque: Option<&str>,
+    params: ChallengeIdParams<'_>,
 ) -> Result<String, std::fmt::Error> {
     type HmacSha256 = Hmac<Sha256>;
 
-    let request_json = stable_json(request)?;
+    let request_json = stable_json(params.request)?;
     let request_b64 = base64url_encode(request_json.as_bytes());
     let hmac_input = [
-        realm,
-        method,
-        intent,
+        params.realm,
+        params.method,
+        params.intent,
         &request_b64,
-        expires.unwrap_or(""),
-        digest.unwrap_or(""),
-        opaque.unwrap_or(""),
+        params.expires.unwrap_or(""),
+        params.digest.unwrap_or(""),
+        params.opaque.unwrap_or(""),
     ]
     .join("|");
 
-    let mut mac =
-        HmacSha256::new_from_slice(secret_key.as_bytes()).expect("HMAC can take key of any size");
+    let mut mac = HmacSha256::new_from_slice(params.secret_key.as_bytes())
+        .expect("HMAC can take key of any size");
     mac.update(hmac_input.as_bytes());
     Ok(base64url_encode(&mac.finalize().into_bytes()))
 }
@@ -572,7 +578,7 @@ fn write_stable_json(output: &mut String, value: &Value) -> Result<(), std::fmt:
         }
         Value::Object(map) => {
             let mut entries = map.iter().collect::<Vec<_>>();
-            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            entries.sort_by_key(|(key, _)| *key);
 
             output.push('{');
             for (index, (key, item)) in entries.into_iter().enumerate() {

--- a/conformance/scripts/harness.py
+++ b/conformance/scripts/harness.py
@@ -158,7 +158,7 @@ class AdapterClient:
     def __init__(self, adapter: AdapterConfig):
         self.adapter = adapter
 
-    def call(self, op: str, input_value: Any, context: dict[str, Any] | None = None, timeout: int = 30) -> dict[str, Any]:
+    def call(self, op: str, input_value: Any, context: dict[str, Any] | None = None, timeout: float = 30) -> dict[str, Any]:
         if op not in self.adapter.capabilities:
             return {
                 "ok": False,
@@ -222,7 +222,7 @@ class AdapterClient:
             }
         return response
 
-    def run_legacy_command(self, command: str, input_data: str) -> dict[str, Any]:
+    def run_legacy_command(self, command: str, input_data: str, timeout: float = 30) -> dict[str, Any]:
         op, input_value = request_input_for_command(command, input_data)
-        response = self.call(op, input_value)
+        response = self.call(op, input_value, timeout=timeout)
         return legacy_response_for_operation(op, response)

--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Tests for vector runner helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+from harness import AdapterConfig
+from vector_runner import VectorRunner
+
+
+class VectorRunnerHelperTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = VectorRunner(output_format="json")
+        self.adapter = AdapterConfig(name="python", command=["python"], capabilities=[])
+
+    def test_duration_limit_prefers_adapter_specific_value(self) -> None:
+        scenario = {
+            "maxDurationMs": 10000,
+            "maxDurationMsByAdapter": {
+                "python": 5000,
+            },
+        }
+
+        self.assertEqual(self.runner.duration_limit_ms(scenario, self.adapter), 5000)
+
+    def test_command_timeout_leaves_room_for_reporting_duration_failure(self) -> None:
+        self.assertEqual(self.runner.command_timeout_seconds(None), 30.0)
+        self.assertEqual(self.runner.command_timeout_seconds(5000), 6.0)
+        self.assertEqual(self.runner.command_timeout_seconds(100), 1.1)
+
+    def test_compare_duration_reports_budget_exceeded(self) -> None:
+        passed, error = self.runner.compare_duration(5000, 5000.1)
+
+        self.assertFalse(passed)
+        self.assertEqual(error, "duration exceeded: expected <= 5000 ms, got 5000.1 ms")
+
+    def test_scenario_wire_expands_repeat_shorthand(self) -> None:
+        scenario = {
+            "wire": {
+                "prefix": "a",
+                "repeat": "bc",
+                "count": 3,
+                "suffix": "d",
+            },
+        }
+
+        self.assertEqual(self.runner.scenario_wire(scenario), "abcbcbcd")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -20,6 +20,7 @@ import argparse
 import base64
 import json
 import sys
+import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -146,13 +147,51 @@ class VectorRunner:
         return {"success": False, "error": message, "error_type": "unknown_error"}
 
     def run_adapter(
-        self, adapter: AdapterConfig, command: str, input_data: str
+        self, adapter: AdapterConfig, command: str, input_data: str, timeout: float = 30
     ) -> dict[str, Any]:
         """Run an adapter operation through the schema-backed JSON ABI."""
         try:
-            return AdapterClient(adapter).run_legacy_command(command, input_data)
+            return AdapterClient(adapter).run_legacy_command(command, input_data, timeout=timeout)
         except Exception as exc:
             return self._error_result(str(exc))
+
+    def run_adapter_timed(
+        self, adapter: AdapterConfig, command: str, input_data: str, timeout: float = 30
+    ) -> tuple[dict[str, Any], float]:
+        start = time.perf_counter()
+        result = self.run_adapter(adapter, command, input_data, timeout=timeout)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        return result, elapsed_ms
+
+    def duration_limit_ms(self, scenario: dict[str, Any], adapter: AdapterConfig) -> int | None:
+        per_adapter = scenario.get("maxDurationMsByAdapter", {})
+        if isinstance(per_adapter, dict) and adapter.name in per_adapter:
+            return int(per_adapter[adapter.name])
+        value = scenario.get("maxDurationMs")
+        return int(value) if value is not None else None
+
+    def compare_duration(
+        self, limit_ms: int | None, elapsed_ms: float
+    ) -> tuple[bool, str | None]:
+        if limit_ms is None or elapsed_ms <= limit_ms:
+            return True, None
+        return False, f"duration exceeded: expected <= {limit_ms} ms, got {elapsed_ms:.1f} ms"
+
+    def command_timeout_seconds(self, duration_limit_ms: int | None) -> float:
+        if duration_limit_ms is None:
+            return 30.0
+        return max(1.0, (duration_limit_ms / 1000) + 1.0)
+
+    def scenario_wire(self, scenario: dict[str, Any]) -> str | None:
+        wire = scenario.get("wire")
+        if not isinstance(wire, dict):
+            return wire
+
+        prefix = wire.get("prefix", "")
+        repeat = wire.get("repeat", "")
+        count = int(wire.get("count", 0))
+        suffix = wire.get("suffix", "")
+        return f"{prefix}{repeat * count}{suffix}"
 
     def _compare_success_and_error_type(
         self, expected: dict[str, Any], actual: dict[str, Any]
@@ -323,17 +362,25 @@ class VectorRunner:
         is_challenge_id = generate_cmd is not None
 
         for scenario in vectors.get("scenarios", []):
+            scenario_adapters = scenario.get("adapters")
+            if scenario_adapters and adapter.name not in scenario_adapters:
+                continue
+
             if tag_filter and tag_filter not in scenario.get("tags", []):
                 continue
 
             name = scenario["name"]
             tests = scenario.get("tests", {})
+            duration_limit_ms = self.duration_limit_ms(scenario, adapter)
+            command_timeout = self.command_timeout_seconds(duration_limit_ms)
 
             if is_challenge_id:
                 input_data = json.dumps(scenario["input"])
-                result = self.run_adapter(adapter, generate_cmd, input_data)
+                result, elapsed_ms = self.run_adapter_timed(adapter, generate_cmd, input_data, timeout=command_timeout)
                 expected = {"success": True, "result": scenario["expected"]}
                 passed, error = self.compare_results(expected, result)
+                if passed:
+                    passed, error = self.compare_duration(duration_limit_ms, elapsed_ms)
                 self._record_result(
                     vector_file=vector_name,
                     test_type=TestType.GENERATE,
@@ -351,18 +398,20 @@ class VectorRunner:
                 wire = scenario.get("encoded")
             else:
                 obj = scenario.get("object")
-                wire = scenario.get("wire")
+                wire = self.scenario_wire(scenario)
 
             # Parse test
             parse_test = tests.get("parse")
             if parse_test is not None and parse_cmd and wire is not None:
-                result = self.run_adapter(adapter, parse_cmd, wire)
+                result, elapsed_ms = self.run_adapter_timed(adapter, parse_cmd, wire, timeout=command_timeout)
                 if parse_test is True:
                     expected = {"success": True, "result": obj}
                     passed, error = self.compare_parse_results_semantic(expected, result, parse_cmd)
                 else:
                     expected = parse_test
                     passed, error = self.compare_results(parse_test, result)
+                if passed:
+                    passed, error = self.compare_duration(duration_limit_ms, elapsed_ms)
                 self._record_result(
                     vector_file=vector_name,
                     test_type=TestType.PARSE,
@@ -380,9 +429,11 @@ class VectorRunner:
                     format_input = obj
                 else:
                     format_input = json.dumps(obj)
-                result = self.run_adapter(adapter, format_cmd, format_input)
+                result, elapsed_ms = self.run_adapter_timed(adapter, format_cmd, format_input, timeout=command_timeout)
                 expected_format = {"success": True, "result": wire}
                 passed, error = self.compare_format_results_semantic(adapter, expected_format, result, format_cmd, parse_cmd)
+                if passed:
+                    passed, error = self.compare_duration(duration_limit_ms, elapsed_ms)
                 self._record_result(
                     vector_file=vector_name,
                     test_type=TestType.FORMAT,
@@ -400,7 +451,7 @@ class VectorRunner:
                     format_input = obj
                 else:
                     format_input = json.dumps(obj)
-                format_result = self.run_adapter(adapter, format_cmd, format_input)
+                format_result = self.run_adapter(adapter, format_cmd, format_input, timeout=command_timeout)
 
                 if not format_result.get("success"):
                     self._record_result(
@@ -416,7 +467,7 @@ class VectorRunner:
                     continue
 
                 formatted = format_result["result"]
-                parse_result = self.run_adapter(adapter, parse_cmd, formatted)
+                parse_result = self.run_adapter(adapter, parse_cmd, formatted, timeout=command_timeout)
 
                 if not parse_result.get("success"):
                     self._record_result(

--- a/conformance/vectors/www-authenticate.json
+++ b/conformance/vectors/www-authenticate.json
@@ -139,6 +139,30 @@
       }
     },
     {
+      "name": "adversarial_unclosed_quoted_extension",
+      "description": "Malformed quoted extension auth-param with many escapes is ignored without pathological parser backtracking",
+      "tags": ["happy-path", "edge-case", "quoted-string", "performance", "oss-319"],
+      "adapters": ["python"],
+      "maxDurationMsByAdapter": {
+        "python": 5000
+      },
+      "object": {
+        "id": "ch_redos",
+        "intent": "charge",
+        "method": "tempo",
+        "realm": "api.example.com",
+        "request": {}
+      },
+      "wire": {
+        "prefix": "Payment id=\"ch_redos\", realm=\"api.example.com\", method=\"tempo\", intent=\"charge\", request=\"e30\", fuzz=\"",
+        "repeat": "\\",
+        "count": 12000
+      },
+      "tests": {
+        "parse": true
+      }
+    },
+    {
       "name": "error_missing_payment_prefix",
       "description": "Rejects header without Payment prefix",
       "tags": ["error", "invalid-prefix"],


### PR DESCRIPTION
## Description

Closes OSS-319

Adds timing-budget support to the vector runner and a Python-only WWW-Authenticate parser stress vector for adversarial quoted auth-params.

Also adds focused runner helper tests and fixes current nightly clippy findings in the Rust adapter.