### PR TITLE
feat: add Swift conformance adapter

### DIFF
--- a/.github/actions/setup-conformance/action.yml
+++ b/.github/actions/setup-conformance/action.yml
@@ -74,6 +74,12 @@ runs:
         bundler-cache: ${{ inputs.ruby-bundler-cache }}
         working-directory: ${{ inputs.conformance-directory }}/adapters/ruby
 
+    - name: Setup Swift
+      if: inputs.adapter == 'swift' || inputs.adapter == 'all'
+      uses: swift-actions/setup-swift@v3
+      with:
+        swift-version: "6.2"
+
     - name: Install uv
       if: inputs.adapter == 'python' || inputs.adapter == 'all'
       uses: astral-sh/setup-uv@v7

--- a/.github/actions/setup-conformance/action.yml
+++ b/.github/actions/setup-conformance/action.yml
@@ -79,6 +79,7 @@ runs:
       uses: swift-actions/setup-swift@v3
       with:
         swift-version: "6.2"
+        skip-verify-signature: "true"
 
     - name: Install uv
       if: inputs.adapter == 'python' || inputs.adapter == 'all'

--- a/.github/actions/setup-conformance/action.yml
+++ b/.github/actions/setup-conformance/action.yml
@@ -78,7 +78,7 @@ runs:
       if: inputs.adapter == 'swift' || inputs.adapter == 'all'
       uses: swift-actions/setup-swift@v3
       with:
-        swift-version: "6.2"
+        swift-version: "6.2.4"
         skip-verify-signature: "true"
 
     - name: Install uv

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,15 +55,6 @@ updates:
         patterns:
           - "*"
 
-  - package-ecosystem: "swift"
-    directory: "/conformance/adapters/swift"
-    schedule:
-      interval: "weekly"
-    groups:
-      swift-dependencies:
-        patterns:
-          - "*"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,6 +55,15 @@ updates:
         patterns:
           - "*"
 
+  - package-ecosystem: "swift"
+    directory: "/conformance/adapters/swift"
+    schedule:
+      interval: "weekly"
+    groups:
+      swift-dependencies:
+        patterns:
+          - "*"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -120,6 +120,13 @@ jobs:
           ./gradlew --no-daemon dependencies --write-locks
           git diff --exit-code -- gradle.lockfile
 
+      - name: Check Swift package resolution
+        if: matrix.adapter == 'swift'
+        run: |
+          cd adapters/swift
+          swift package resolve
+          git diff --exit-code -- Package.resolved
+
       - name: Install adapter dependencies
         run: make ${{ matrix.install-target }}
 
@@ -174,6 +181,13 @@ jobs:
           cd adapters/java
           ./gradlew --no-daemon dependencies --write-locks
           git diff --exit-code -- gradle.lockfile
+
+      - name: Check Swift package resolution
+        if: matrix.adapter == 'swift'
+        run: |
+          cd adapters/swift
+          swift package resolve
+          git diff --exit-code -- Package.resolved
 
       - name: Install adapter dependencies
         if: matrix.adapter != 'typescript'

--- a/.github/workflows/sdk-conformance.yml
+++ b/.github/workflows/sdk-conformance.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       adapter:
-        description: SDK adapter to test, for example rust, ruby, go, python, or typescript. Java is tested by mpp-tools CI only because local SDK override support is not implemented.
+        description: SDK adapter to test, for example rust, ruby, go, python, swift, or typescript. Java is tested by mpp-tools CI only because local SDK override support is not implemented.
         required: true
         type: string
       conformance-ref:
@@ -47,7 +47,7 @@ jobs:
         run: |
           adapter=$(printf '%s' "$REQUESTED_ADAPTER" | tr '[:upper:]' '[:lower:]')
           case "$adapter" in
-            go|python|ruby|rust|typescript)
+            go|python|ruby|rust|swift|typescript)
               ;;
             *)
               echo "Unsupported adapter: $REQUESTED_ADAPTER" >&2
@@ -108,6 +108,10 @@ jobs:
             rust)
               cd adapters/rust
               cargo fetch
+              ;;
+            swift)
+              cd adapters/swift
+              swift package resolve
               ;;
             typescript)
               npm install

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ conformance/adapters/ruby/.bundle/
 conformance/adapters/ruby/vendor/
 conformance/adapters/java/.gradle/
 conformance/adapters/java/build/
+conformance/adapters/swift/.build/

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ cd conformance
 make all
 ```
 
-This installs the pinned SDK releases, runs the vector suite, and runs the end-to-end 402 flow suite.
+This installs the default public SDK releases, runs the vector suite, and runs the end-to-end 402 flow suite.
 
 Run individual stages while developing:
 
 ```bash
-make install      # install pinned SDKs and adapter dependencies
-make test         # run vector conformance against all adapters
+make install      # install default public SDKs and adapter dependencies
+make test         # run vector conformance against default adapters
 make flow         # run end-to-end 402 flow conformance
 ```
 
@@ -95,7 +95,8 @@ The harness validates the SDKs declared by the adapter manifests in `conformance
 | `mpp-go` | Go | [tempoxyz/mpp-go](https://github.com/tempoxyz/mpp-go) | [Go module](https://pkg.go.dev/github.com/tempoxyz/mpp-go) |
 | `mpp-rb` | Ruby | [stripe/mpp-rb](https://github.com/stripe/mpp-rb) | [RubyGems](https://rubygems.org/gems/mpp-rb) |
 | `mpp-java` | Java | [stripe/mpp-java](https://github.com/stripe/mpp-java) | JitPack Maven |
-| `mpp-swift` | Swift | [tempoxyz/mpp-swift](https://github.com/tempoxyz/mpp-swift) | SwiftPM |
+
+The Swift adapter is checked in as an explicit private preview for maintainers with access to `tempoxyz/mpp-swift`. It can be run with `make test-swift` and `make flow-swift`, but it is not part of default public CI until the Swift SDK repository is public or CI has credentials.
 
 ## Updating SDK Pins
 
@@ -115,7 +116,8 @@ SDK versions are pinned in package-manager manifests and lockfiles:
 | Go | `github.com/tempoxyz/mpp-go` | `adapters/go/go.mod` / `go.sum` |
 | Ruby | `mpp-rb` | `adapters/ruby/Gemfile` / `Gemfile.lock` |
 | Java | `com.github.stripe:mpp-java` | `adapters/java/build.gradle` / `gradle.lockfile` |
-| Swift | `mpp-swift` | `adapters/swift/Package.swift` / `Package.resolved` |
+
+SwiftPM pins for `mpp-swift` live in `adapters/swift/Package.swift` and `Package.resolved`, and are updated explicitly with `make update-swift` while the SDK repository is private.
 
 ## Protocol
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The harness validates the SDKs declared by the adapter manifests in `conformance
 | `mpp-go` | Go | [tempoxyz/mpp-go](https://github.com/tempoxyz/mpp-go) | [Go module](https://pkg.go.dev/github.com/tempoxyz/mpp-go) |
 | `mpp-rb` | Ruby | [stripe/mpp-rb](https://github.com/stripe/mpp-rb) | [RubyGems](https://rubygems.org/gems/mpp-rb) |
 | `mpp-java` | Java | [stripe/mpp-java](https://github.com/stripe/mpp-java) | JitPack Maven |
+| `mpp-swift` | Swift | [tempoxyz/mpp-swift](https://github.com/tempoxyz/mpp-swift) | SwiftPM |
 
 ## Updating SDK Pins
 
@@ -114,6 +115,7 @@ SDK versions are pinned in package-manager manifests and lockfiles:
 | Go | `github.com/tempoxyz/mpp-go` | `adapters/go/go.mod` / `go.sum` |
 | Ruby | `mpp-rb` | `adapters/ruby/Gemfile` / `Gemfile.lock` |
 | Java | `com.github.stripe:mpp-java` | `adapters/java/build.gradle` / `gradle.lockfile` |
+| Swift | `mpp-swift` | `adapters/swift/Package.swift` / `Package.resolved` |
 
 ## Protocol
 

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -27,7 +27,6 @@ update-locks:
 	cd adapters/go && GOTOOLCHAIN=auto go get -u github.com/tempoxyz/mpp-go && GOTOOLCHAIN=auto go mod tidy
 	cd adapters/ruby && $(BUNDLE) lock --update mpp-rb sorbet-runtime
 	cd adapters/java && ./gradlew --no-daemon dependencies --write-locks
-	cd adapters/swift && swift package update mpp-swift
 
 # SDK pins live in package manager manifests and lockfiles:
 # - TypeScript: package.json/package-lock.json
@@ -36,14 +35,14 @@ update-locks:
 # - Go: adapters/go/go.mod/go.sum
 # - Ruby: adapters/ruby/Gemfile/Gemfile.lock
 # - Java: adapters/java/build.gradle/gradle.lockfile
-# - Swift: adapters/swift/Package.swift/Package.resolved
+# - Swift: adapters/swift/Package.swift/Package.resolved (explicit/private preview)
 
 #------------------------------------------------------------------------------
 # Installation
 #------------------------------------------------------------------------------
 
-install: install-ts install-rust install-python install-go install-ruby install-java install-swift install-scripts
-	@echo "✓ All adapters installed"
+install: install-ts install-rust install-python install-go install-ruby install-java install-scripts
+	@echo "✓ Default adapters installed"
 
 install-runner: install-ts install-scripts
 	@echo "✓ Conformance runner installed"
@@ -138,7 +137,7 @@ update-flow-golden:
 	python3 scripts/flow_runner.py --update-golden
 
 test-all:
-	@echo "→ Running conformance tests for all adapters..."
+	@echo "→ Running conformance tests for default adapters..."
 	python3 scripts/vector_runner.py
 
 test-typescript:
@@ -220,13 +219,15 @@ help:
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Targets:"
-	@echo "  all              Install pinned SDK releases and run vectors + flows"
-	@echo "  update-locks     Update pinned SDK package locks"
+	@echo "  all              Install default public SDK releases and run vectors + flows"
+	@echo "  update-locks     Update default public SDK package locks"
 	@echo "  update-java      Update the Java adapter Gradle lockfile"
-	@echo "  install          Install all adapter dependencies"
+	@echo "  update-swift     Update the Swift adapter package resolution"
+	@echo "  install          Install default public adapter dependencies"
 	@echo "  install-runner   Install shared runner dependencies only"
+	@echo "  install-swift    Build the explicit Swift adapter"
 	@echo "  use-local-sdk    Point one adapter at SDK_PATH, e.g. ADAPTER=rust SDK_PATH=../mpp-rs"
-	@echo "  test             Run conformance tests for all adapters"
+	@echo "  test             Run conformance tests for default adapters"
 	@echo "  test-sdk         Run vector tests for ADAPTER"
 	@echo "  flow             Run flow conformance tests"
 	@echo "  flow-sdk         Run flow tests for ADAPTER"
@@ -254,3 +255,4 @@ help:
 	@echo "  Go:         github.com/tempoxyz/mpp-go (Go module)"
 	@echo "  Ruby:       mpp-rb (Bundler/RubyGems)"
 	@echo "  Java:       com.github.stripe:mpp-java (Gradle/JitPack)"
+	@echo "  Swift:      mpp-swift (SwiftPM, explicit/private preview)"

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -1,7 +1,7 @@
 # Conformance Testing Makefile
 # Cross-SDK protocol compatibility testing for MPP implementations
 
-.PHONY: all update-locks update-java install install-runner install-java use-local-sdk test test-all test-sdk test-typescript test-rust test-python test-go test-ruby test-java test-json flow flow-sdk flow-typescript flow-rust flow-python flow-go flow-ruby flow-java update-flow-golden clean help
+.PHONY: all update-locks update-java update-swift install install-runner install-java install-swift use-local-sdk test test-all test-sdk test-typescript test-rust test-python test-go test-ruby test-java test-swift test-json flow flow-sdk flow-typescript flow-rust flow-python flow-go flow-ruby flow-java flow-swift update-flow-golden clean help
 
 RUBY ?= ruby
 BUNDLE ?= bundle
@@ -27,6 +27,7 @@ update-locks:
 	cd adapters/go && GOTOOLCHAIN=auto go get -u github.com/tempoxyz/mpp-go && GOTOOLCHAIN=auto go mod tidy
 	cd adapters/ruby && $(BUNDLE) lock --update mpp-rb sorbet-runtime
 	cd adapters/java && ./gradlew --no-daemon dependencies --write-locks
+	cd adapters/swift && swift package update mpp-swift
 
 # SDK pins live in package manager manifests and lockfiles:
 # - TypeScript: package.json/package-lock.json
@@ -35,12 +36,13 @@ update-locks:
 # - Go: adapters/go/go.mod/go.sum
 # - Ruby: adapters/ruby/Gemfile/Gemfile.lock
 # - Java: adapters/java/build.gradle/gradle.lockfile
+# - Swift: adapters/swift/Package.swift/Package.resolved
 
 #------------------------------------------------------------------------------
 # Installation
 #------------------------------------------------------------------------------
 
-install: install-ts install-rust install-python install-go install-ruby install-java install-scripts
+install: install-ts install-rust install-python install-go install-ruby install-java install-swift install-scripts
 	@echo "✓ All adapters installed"
 
 install-runner: install-ts install-scripts
@@ -78,6 +80,10 @@ install-ruby:
 install-java:
 	@echo "→ Building Java adapter..."
 	cd adapters/java && ./gradlew --no-daemon installDist
+
+install-swift:
+	@echo "→ Building Swift adapter..."
+	cd adapters/swift && swift build -c release --quiet
 
 #------------------------------------------------------------------------------
 # Testing
@@ -123,6 +129,10 @@ flow-java:
 	@echo "→ Running Java flow conformance tests..."
 	python3 scripts/flow_runner.py --adapter java
 
+flow-swift:
+	@echo "→ Running Swift flow conformance tests..."
+	python3 scripts/flow_runner.py --adapter swift
+
 update-flow-golden:
 	@echo "→ Updating flow golden results..."
 	python3 scripts/flow_runner.py --update-golden
@@ -155,6 +165,10 @@ test-java:
 	@echo "→ Testing Java adapter..."
 	python3 scripts/vector_runner.py --adapter java
 
+test-swift:
+	@echo "→ Testing Swift adapter..."
+	python3 scripts/vector_runner.py --adapter swift
+
 test-json:
 	@echo "→ Running conformance tests (JSON output)..."
 	python3 scripts/vector_runner.py --output json
@@ -182,6 +196,7 @@ clean:
 	rm -rf adapters/python/.venv adapters/python/__pycache__ adapters/python/*.egg-info
 	rm -rf adapters/ruby/.bundle adapters/ruby/vendor
 	rm -rf adapters/java/build adapters/java/.gradle
+	rm -rf adapters/swift/.build
 
 update-rust:
 	cd adapters/rust && cargo update -p mpp
@@ -191,6 +206,9 @@ update-python:
 
 update-java:
 	cd adapters/java && ./gradlew --no-daemon dependencies --write-locks
+
+update-swift:
+	cd adapters/swift && swift package update mpp-swift
 
 #------------------------------------------------------------------------------
 # Help
@@ -218,6 +236,7 @@ help:
 	@echo "  test-python      Test Python adapter only"
 	@echo "  test-go          Test Go adapter only"
 	@echo "  test-ruby        Test Ruby adapter only"
+	@echo "  test-swift       Test Swift adapter only"
 	@echo "  test-java        Test Java adapter only"
 	@echo "  flow-typescript  Run TypeScript flow conformance tests only"
 	@echo "  flow-rust        Run Rust flow conformance tests only"

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,20 +1,20 @@
 # Conformance Test Suite
 
-Cross-SDK protocol compatibility testing for [MPP](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/) implementations. Ensures the TypeScript golden fixtures plus Rust, Python, Go, Ruby, and Java SDKs produce **identical outputs** for the same inputs.
+Cross-SDK protocol compatibility testing for [MPP](https://datatracker.ietf.org/doc/draft-ietf-httpauth-payment/) implementations. Ensures the TypeScript golden fixtures plus Rust, Python, Go, Ruby, and Java SDKs produce **identical outputs** for the same inputs. A Swift adapter is also checked in as an explicit private preview while `tempoxyz/mpp-swift` remains private.
 
-The harness installs pinned SDK releases from each language package manager. Dependabot opens SDK bump PRs when newer releases are available, and conformance is the compatibility gate for those bumps.
+The harness installs pinned default public SDK releases from each language package manager. Dependabot opens SDK bump PRs when newer public releases are available, and conformance is the compatibility gate for those bumps.
 
 ## Quick Start
 
 ```bash
-make all          # install pinned SDKs, run vectors + flows
+make all          # install default public SDKs, run vectors + flows
 ```
 
 Or step by step:
 
 ```bash
 make install      # install the pinned TS/Rust/Python/Go/Ruby/Java releases
-make test         # run SDK adapters against all vectors
+make test         # run default SDK adapters against all vectors
 make flow         # run the end-to-end flow suite against golden results
 ```
 
@@ -28,7 +28,7 @@ Each SDK has a thin **adapter** CLI that wraps its library and exposes a uniform
 vectors/*.json ──► vector_runner.py ──► adapter (Rust/Python/Go/Ruby/Java) ──► pass/fail
 ```
 
-The TypeScript adapter remains the golden implementation for fixture maintenance and can be run explicitly with `make test-typescript`. Default vector runs skip it because the vector JSON files are the checked golden source of truth.
+The TypeScript adapter remains the golden implementation for fixture maintenance and can be run explicitly with `make test-typescript`. Default vector runs skip adapters that require private credentials.
 
 See [`HARNESS_SPEC.md`](./HARNESS_SPEC.md) for the schema-backed adapter ABI, manifest format, operation registry, migration plan, and language skeletons.
 
@@ -108,7 +108,7 @@ Adapter locations:
 | Go | `adapters/go/` |
 | Ruby (`mpp-rb`) | `adapters/ruby/` |
 | Java (`mpp-java`) | `adapters/java/` |
-| Swift (`mpp-swift`) | `adapters/swift/` |
+| Swift (`mpp-swift`) | `adapters/swift/` explicit/private preview |
 
 ## SDK Versions
 
@@ -122,11 +122,13 @@ SDK pins live in package-manager manifests and lockfiles where the ecosystem sup
 | Go | `github.com/tempoxyz/mpp-go` | `adapters/go/go.mod` / `go.sum` |
 | Ruby | `mpp-rb` | `adapters/ruby/Gemfile` / `Gemfile.lock` |
 | Java | `com.github.stripe:mpp-java` | `adapters/java/build.gradle` / `gradle.lockfile` |
-| Swift | `mpp-swift` | `adapters/swift/Package.swift` / `Package.resolved` |
+| Swift | `mpp-swift` | `adapters/swift/Package.swift` / `Package.resolved` explicit/private preview |
 
 Dependabot checks all configured package managers daily and opens PRs when updates are available. Every PR runs vector and flow conformance in CI, so dependency bump PRs are gated by the same compatibility suite.
 
 The Java adapter currently pins `mpp-java` to an exact JitPack commit because `mpp-java` does not publish versioned Maven releases yet. Update `adapters/java/build.gradle` manually and run `make update-java` when changing that pin.
+
+The Swift adapter depends on the private `tempoxyz/mpp-swift` repository for now. Run `make install-swift`, `make test-swift`, `make flow-swift`, or `make update-swift` only from an environment with access to that repository.
 
 ## Running Specific Tests
 
@@ -256,7 +258,7 @@ make flow-sdk ADAPTER=rust
 
 1. Edit the appropriate vector file in `vectors/`
 2. Add a new scenario object to the `scenarios` array
-3. Run `make test` to verify all adapters pass
+3. Run `make test` to verify default adapters pass, plus any explicit/private-preview adapter affected by the scenario
 4. Submit a PR
 
 ## Prerequisites

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -108,6 +108,7 @@ Adapter locations:
 | Go | `adapters/go/` |
 | Ruby (`mpp-rb`) | `adapters/ruby/` |
 | Java (`mpp-java`) | `adapters/java/` |
+| Swift (`mpp-swift`) | `adapters/swift/` |
 
 ## SDK Versions
 
@@ -121,6 +122,7 @@ SDK pins live in package-manager manifests and lockfiles where the ecosystem sup
 | Go | `github.com/tempoxyz/mpp-go` | `adapters/go/go.mod` / `go.sum` |
 | Ruby | `mpp-rb` | `adapters/ruby/Gemfile` / `Gemfile.lock` |
 | Java | `com.github.stripe:mpp-java` | `adapters/java/build.gradle` / `gradle.lockfile` |
+| Swift | `mpp-swift` | `adapters/swift/Package.swift` / `Package.resolved` |
 
 Dependabot checks all configured package managers daily and opens PRs when updates are available. Every PR runs vector and flow conformance in CI, so dependency bump PRs are gated by the same compatibility suite.
 
@@ -136,6 +138,7 @@ make test-python
 make test-go
 make test-ruby
 make test-java
+make test-swift
 
 # Single vector file
 python3 scripts/vector_runner.py --vector www-authenticate
@@ -190,6 +193,7 @@ Use the matching adapter name in each SDK repository:
 | [`tempoxyz/mpp-go`](https://github.com/tempoxyz/mpp-go) | `go` |
 | [`tempoxyz/pympp`](https://github.com/tempoxyz/pympp) | `python` |
 | [`wevm/mppx`](https://github.com/wevm/mppx) | `typescript` |
+| [`tempoxyz/mpp-swift`](https://github.com/tempoxyz/mpp-swift) | `swift` |
 
 Then make the called `conformance` job a required branch-protection or ruleset
 check in the SDK repository.
@@ -263,4 +267,5 @@ make flow-sdk ADAPTER=rust
 - Go with toolchain auto-download enabled or Go ≥ 1.26 (for the Go adapter)
 - Ruby ≥ 3.3 + Bundler (for the `mpp-rb` adapter)
 - JDK 17 or newer (for the Java adapter; it builds Java 11 bytecode)
+- Swift ≥ 6.2 (for the Swift adapter)
 - `python3 -m pip install -r requirements.txt` (for the test runner)

--- a/conformance/adapters/swift/Package.resolved
+++ b/conformance/adapters/swift/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "mpp-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tempoxyz/mpp-swift.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "142f7694f3dd78e21a61144b78ec93981f8dc347"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/conformance/adapters/swift/Package.swift
+++ b/conformance/adapters/swift/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "mpp-swift-conformance-adapter",
+    platforms: [
+        .macOS(.v13),
+    ],
+    products: [
+        .executable(name: "swift-adapter", targets: ["SwiftAdapter"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/tempoxyz/mpp-swift.git", branch: "main"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwiftAdapter",
+            dependencies: [
+                .product(name: "MPP", package: "mpp-swift"),
+            ]
+        ),
+    ]
+)

--- a/conformance/adapters/swift/Sources/SwiftAdapter/main.swift
+++ b/conformance/adapters/swift/Sources/SwiftAdapter/main.swift
@@ -1,0 +1,348 @@
+import CryptoKit
+import Foundation
+import MPP
+
+struct AdapterRequest: Decodable {
+    let op: String
+    let input: JSONValue
+}
+
+struct HeaderInput: Codable {
+    let header: String
+}
+
+struct HeaderOutput: Encodable {
+    let header: String
+}
+
+struct TextValue: Codable {
+    let text: String
+}
+
+struct ChallengeIdInput: Codable {
+    let secretKey: String
+    let realm: String
+    let method: String
+    let intent: String
+    let request: [String: JSONValue]
+    let expires: String?
+    let description: String?
+    let digest: String?
+    let opaque: String?
+}
+
+struct ChallengeIdOutput: Encodable {
+    let id: String
+}
+
+struct WireChallenge: Codable {
+    let id: String
+    let realm: String
+    let method: String
+    let intent: String
+    let request: [String: JSONValue]
+    let expires: String?
+    let description: String?
+    let digest: String?
+    let opaque: String?
+
+    init(
+        id: String,
+        realm: String,
+        method: String,
+        intent: String,
+        request: [String: JSONValue],
+        expires: String? = nil,
+        description: String? = nil,
+        digest: String? = nil,
+        opaque: String? = nil
+    ) {
+        self.id = id
+        self.realm = realm
+        self.method = method
+        self.intent = intent
+        self.request = request
+        self.expires = expires
+        self.description = description
+        self.digest = digest
+        self.opaque = opaque
+    }
+
+    init(_ challenge: Challenge) {
+        self.init(
+            id: challenge.id,
+            realm: challenge.realm,
+            method: challenge.method,
+            intent: challenge.intent,
+            request: challenge.request,
+            expires: challenge.expires,
+            description: challenge.description,
+            digest: challenge.digest,
+            opaque: challenge.opaque.map { JSONValue.object($0.mapValues(JSONValue.string)).canonicalJSON() }
+        )
+    }
+
+    var sdkChallenge: Challenge {
+        Challenge(
+            id: id,
+            realm: realm,
+            method: method,
+            intent: intent,
+            request: request,
+            description: description,
+            digest: digest,
+            expires: expires
+        )
+    }
+}
+
+struct WireCredential: Codable {
+    let challenge: WireChallenge
+    let payload: [String: JSONValue]
+    let source: JSONValue?
+}
+
+struct WireReceipt: Codable {
+    let status: String
+    let method: String?
+    let timestamp: String
+    let reference: String
+    let externalId: String?
+    let extra: [String: JSONValue]?
+
+    init(_ receipt: Receipt) {
+        self.status = receipt.status
+        self.method = receipt.method
+        self.timestamp = receipt.timestamp
+        self.reference = receipt.reference
+        self.externalId = receipt.externalId
+        self.extra = nil
+    }
+
+    func sdkReceipt(errorType: String) throws -> Receipt {
+        guard let method else {
+            throw AdapterFailure(type: errorType, message: "receipt missing method")
+        }
+        return Receipt(
+            status: status,
+            method: method,
+            timestamp: timestamp,
+            reference: reference,
+            externalId: externalId
+        )
+    }
+}
+
+struct AdapterFailure: Error {
+    let type: String
+    let message: String
+}
+
+let input = FileHandle.standardInput.readDataToEndOfFile()
+
+do {
+    let request = try JSONDecoder().decode(AdapterRequest.self, from: input)
+    let value = try run(request)
+    printJSON(["ok": JSONValue.bool(true), "value": value])
+} catch let failure as AdapterFailure {
+    printJSON([
+        "ok": JSONValue.bool(false),
+        "error": .object([
+            "type": .string(failure.type),
+            "message": .string(failure.message),
+        ]),
+    ])
+} catch {
+    printJSON([
+        "ok": JSONValue.bool(false),
+        "error": .object([
+            "type": .string("unknown_error"),
+            "message": .string(String(describing: error)),
+        ]),
+    ])
+}
+
+func run(_ request: AdapterRequest) throws -> JSONValue {
+    switch request.op {
+    case "challenge.parse":
+        let input: HeaderInput = try decodeInput(request.input, errorType: "parse_error")
+        let challenge = try mapError("parse_error") { try Challenge.deserialize(input.header) }
+        try validateChallenge(challenge, errorType: "parse_error")
+        return try encodeValue(WireChallenge(challenge), errorType: "parse_error")
+
+    case "challenge.format":
+        let challenge: WireChallenge = try decodeInput(request.input, errorType: "format_error")
+        let header: String
+        if let opaque = challenge.opaque {
+            header = formatChallengeHeader(challenge, opaque: opaque)
+        } else {
+            header = Challenge.serialize(challenge.sdkChallenge)
+        }
+        return try encodeValue(HeaderOutput(header: header), errorType: "format_error")
+
+    case "credential.parse":
+        let input: HeaderInput = try decodeInput(request.input, errorType: "parse_error")
+        let credential = try mapError("parse_error") { try Credential.deserialize(input.header) }
+        try validateChallenge(credential.challenge, errorType: "parse_error")
+        let value = WireCredential(
+            challenge: WireChallenge(credential.challenge),
+            payload: credential.payload,
+            source: credential.source.map(JSONValue.string)
+        )
+        return try encodeValue(value, errorType: "parse_error")
+
+    case "credential.format":
+        let credential: WireCredential = try decodeInput(request.input, errorType: "format_error")
+        let source = try stringSource(credential.source)
+        let sdkCredential = Credential(
+            challenge: credential.challenge.sdkChallenge,
+            payload: credential.payload,
+            source: source
+        )
+        return try encodeValue(
+            HeaderOutput(header: Credential.serialize(sdkCredential)),
+            errorType: "format_error"
+        )
+
+    case "receipt.parse":
+        let input: HeaderInput = try decodeInput(request.input, errorType: "parse_error")
+        let receipt = try mapError("parse_error") { try Receipt.deserialize(input.header) }
+        try validateTimestamp(receipt.timestamp, errorType: "parse_error")
+        return try encodeValue(WireReceipt(receipt), errorType: "parse_error")
+
+    case "receipt.format":
+        let receipt: WireReceipt = try decodeInput(request.input, errorType: "format_error")
+        try validateTimestamp(receipt.timestamp, errorType: "format_error")
+        let header = try Receipt.serialize(receipt.sdkReceipt(errorType: "format_error"))
+        return try encodeValue(HeaderOutput(header: header), errorType: "format_error")
+
+    case "base64url.encode":
+        let input: TextValue = try decodeInput(request.input, errorType: "encoding_error")
+        return try encodeValue(TextValue(text: Base64URL.encodeString(input.text)), errorType: "encoding_error")
+
+    case "base64url.decode":
+        let input: TextValue = try decodeInput(request.input, errorType: "encoding_error")
+        return try encodeValue(
+            TextValue(text: mapError("encoding_error") { try Base64URL.decodeString(input.text) }),
+            errorType: "encoding_error"
+        )
+
+    case "challenge.id":
+        let input: ChallengeIdInput = try decodeInput(request.input, errorType: "generation_error")
+        return try encodeValue(
+            ChallengeIdOutput(id: generateChallengeId(input)),
+            errorType: "generation_error"
+        )
+
+    default:
+        throw AdapterFailure(type: "unsupported_operation", message: "Unknown operation: \(request.op)")
+    }
+}
+
+func decodeInput<T: Decodable>(_ value: JSONValue, errorType: String) throws -> T {
+    do {
+        return try JSONDecoder().decode(T.self, from: try JSONEncoder().encode(value))
+    } catch {
+        throw AdapterFailure(type: errorType, message: String(describing: error))
+    }
+}
+
+func encodeValue<T: Encodable>(_ value: T, errorType: String) throws -> JSONValue {
+    do {
+        return try JSONDecoder().decode(JSONValue.self, from: try JSONEncoder().encode(value))
+    } catch {
+        throw AdapterFailure(type: errorType, message: String(describing: error))
+    }
+}
+
+func mapError<T>(_ errorType: String, _ body: () throws -> T) throws -> T {
+    do {
+        return try body()
+    } catch {
+        throw AdapterFailure(type: errorType, message: String(describing: error))
+    }
+}
+
+func stringSource(_ source: JSONValue?) throws -> String? {
+    guard let source, !source.isNull else {
+        return nil
+    }
+    guard case let .string(text) = source else {
+        throw AdapterFailure(type: "format_error", message: "source must be a string for mpp-swift")
+    }
+    return text
+}
+
+func validateChallenge(_ challenge: Challenge, errorType: String) throws {
+    if challenge.id.isEmpty {
+        throw AdapterFailure(type: errorType, message: "challenge id is required")
+    }
+    if challenge.method.isEmpty {
+        throw AdapterFailure(type: errorType, message: "challenge method is required")
+    }
+    if challenge.intent.isEmpty {
+        throw AdapterFailure(type: errorType, message: "challenge intent is required")
+    }
+}
+
+func validateTimestamp(_ value: String, errorType: String) throws {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if formatter.date(from: value) != nil {
+        return
+    }
+    formatter.formatOptions = [.withInternetDateTime]
+    if formatter.date(from: value) == nil {
+        throw AdapterFailure(type: errorType, message: "invalid receipt timestamp")
+    }
+}
+
+func generateChallengeId(_ input: ChallengeIdInput) -> String {
+    let requestB64 = PaymentRequest.serialize(PaymentRequest(fields: input.request))
+    let hmacInput = [
+        input.realm,
+        input.method,
+        input.intent,
+        requestB64,
+        input.expires ?? "",
+        input.digest ?? "",
+        input.opaque ?? "",
+    ].joined(separator: "|")
+
+    let key = SymmetricKey(data: Data(input.secretKey.utf8))
+    let mac = HMAC<SHA256>.authenticationCode(for: Data(hmacInput.utf8), using: key)
+    return Base64URL.encode(Data(mac))
+}
+
+func formatChallengeHeader(_ challenge: WireChallenge, opaque: String) -> String {
+    var parts = [
+        "id=\"\(escapeQuoted(challenge.id))\"",
+        "realm=\"\(escapeQuoted(challenge.realm))\"",
+        "method=\"\(escapeQuoted(challenge.method))\"",
+        "intent=\"\(escapeQuoted(challenge.intent))\"",
+        "request=\"\(escapeQuoted(PaymentRequest.serialize(PaymentRequest(fields: challenge.request))))\"",
+    ]
+    if let description = challenge.description {
+        parts.append("description=\"\(escapeQuoted(description))\"")
+    }
+    if let digest = challenge.digest {
+        parts.append("digest=\"\(escapeQuoted(digest))\"")
+    }
+    if let expires = challenge.expires {
+        parts.append("expires=\"\(escapeQuoted(expires))\"")
+    }
+    parts.append("opaque=\"\(escapeQuoted(opaque))\"")
+    return "Payment \(parts.joined(separator: ", "))"
+}
+
+func escapeQuoted(_ value: String) -> String {
+    value
+        .replacingOccurrences(of: "\\", with: "\\\\")
+        .replacingOccurrences(of: "\"", with: "\\\"")
+}
+
+func printJSON(_ value: [String: JSONValue]) {
+    let data = try! JSONEncoder().encode(JSONValue.object(value))
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data("\n".utf8))
+}

--- a/conformance/adapters/swift/adapter.json
+++ b/conformance/adapters/swift/adapter.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../../schemas/adapter-manifest.schema.json",
+  "schema": 1,
+  "name": "swift",
+  "language": "swift",
+  "command": [
+    ".build/release/swift-adapter"
+  ],
+  "build": [
+    "swift",
+    "build",
+    "-c",
+    "release",
+    "--quiet"
+  ],
+  "cwd": ".",
+  "capabilities": [
+    "challenge.parse",
+    "challenge.format",
+    "credential.parse",
+    "credential.format",
+    "receipt.parse",
+    "receipt.format",
+    "base64url.encode",
+    "base64url.decode",
+    "challenge.id"
+  ]
+}

--- a/conformance/scripts/flow_runner.py
+++ b/conformance/scripts/flow_runner.py
@@ -25,6 +25,7 @@ CONFORMANCE_DIR = SCRIPT_DIR.parent
 FLOW_DIR = CONFORMANCE_DIR / "flows"
 FLOW_CASES = FLOW_DIR / "flows.json"
 FLOW_RESULTS = FLOW_DIR / "golden-results.json"
+DEFAULT_FLOW_EXCLUDED_ADAPTERS = {"typescript", "swift"}
 
 
 def normalize_error_type(value: str | None) -> str | None:
@@ -481,7 +482,10 @@ def compare_results(
 
 def selected_adapters(name: str, adapters: dict[str, AdapterConfig]) -> list[str]:
     if name == "all":
-        return [adapter_name for adapter_name in sorted(adapters) if adapter_name != "typescript"]
+        return [
+            adapter_name for adapter_name in sorted(adapters)
+            if adapter_name not in DEFAULT_FLOW_EXCLUDED_ADAPTERS
+        ]
     return [name]
 
 

--- a/conformance/scripts/sdk_version.py
+++ b/conformance/scripts/sdk_version.py
@@ -91,6 +91,20 @@ def java_version() -> str:
     return f"com.github.stripe:mpp-java@{match.group(1)}"
 
 
+def swift_version() -> str:
+    manifest = (ROOT / "adapters/swift/Package.swift").read_text(encoding="utf-8")
+    if ".package(path:" in manifest:
+        return "mpp-swift@local"
+
+    resolved = json.loads((ROOT / "adapters/swift/Package.resolved").read_text(encoding="utf-8"))
+    for pin in resolved.get("pins", []):
+        if pin.get("identity") == "mpp-swift":
+            revision = pin.get("state", {}).get("revision")
+            if revision:
+                return f"mpp-swift@{revision[:12]}"
+    raise RuntimeError("Could not find mpp-swift revision in adapters/swift/Package.resolved")
+
+
 VERSIONS = {
     "typescript": typescript_version,
     "rust": rust_version,
@@ -98,6 +112,7 @@ VERSIONS = {
     "go": go_version,
     "ruby": ruby_version,
     "java": java_version,
+    "swift": swift_version,
 }
 
 

--- a/conformance/scripts/select_ci_adapters.py
+++ b/conformance/scripts/select_ci_adapters.py
@@ -17,6 +17,7 @@ ADAPTER_TARGETS = {
     "go": "install-go",
     "ruby": "install-ruby",
     "java": "install-java",
+    "swift": "install-swift",
 }
 ADAPTER_ORDER = list(ADAPTER_TARGETS)
 
@@ -30,6 +31,7 @@ ADAPTER_PATTERNS = {
     "go": ["conformance/adapters/go/**"],
     "ruby": ["conformance/adapters/ruby/**"],
     "java": ["conformance/adapters/java/**"],
+    "swift": ["conformance/adapters/swift/**"],
 }
 
 FULL_PATTERNS = [

--- a/conformance/scripts/select_ci_adapters.py
+++ b/conformance/scripts/select_ci_adapters.py
@@ -17,7 +17,6 @@ ADAPTER_TARGETS = {
     "go": "install-go",
     "ruby": "install-ruby",
     "java": "install-java",
-    "swift": "install-swift",
 }
 ADAPTER_ORDER = list(ADAPTER_TARGETS)
 
@@ -31,6 +30,9 @@ ADAPTER_PATTERNS = {
     "go": ["conformance/adapters/go/**"],
     "ruby": ["conformance/adapters/ruby/**"],
     "java": ["conformance/adapters/java/**"],
+}
+OPTIONAL_ADAPTER_PATTERNS = {
+    # Swift depends on private mpp-swift repository access until the SDK is public.
     "swift": ["conformance/adapters/swift/**"],
 }
 
@@ -101,6 +103,11 @@ def select_adapters(event_name: str, changed_files: list[str]) -> tuple[list[str
     ]
     if selected:
         return selected, "adapter-specific conformance files changed"
+    if any(
+        any(path_matches(path, pattern) for patterns in OPTIONAL_ADAPTER_PATTERNS.values() for pattern in patterns)
+        for path in changed_files
+    ):
+        return [], "optional adapter files changed; run targeted conformance outside public CI"
     return [], "no conformance-affecting files changed"
 
 

--- a/conformance/scripts/use_local_sdk.py
+++ b/conformance/scripts/use_local_sdk.py
@@ -96,11 +96,22 @@ def configure_typescript(conformance_dir: Path, sdk_path: Path) -> None:
     write_text(package_json, json.dumps(data, indent=2) + "\n")
 
 
+def configure_swift(conformance_dir: Path, sdk_path: Path) -> None:
+    manifest = conformance_dir / "adapters" / "swift" / "Package.swift"
+    replace_one(
+        manifest,
+        r'^(\s*)\.package\(url:\s*"https://github\.com/tempoxyz/mpp-swift\.git",\s*(?:branch|revision):\s*"[^"]+"\),\s*$',
+        rf'\1.package(path: {json_string(sdk_path)}),',
+        "Swift mpp-swift dependency",
+    )
+
+
 CONFIGURERS = {
     "go": configure_go,
     "python": configure_python,
     "ruby": configure_ruby,
     "rust": configure_rust,
+    "swift": configure_swift,
     "typescript": configure_typescript,
 }
 

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -32,6 +32,7 @@ from harness import AdapterClient, AdapterConfig, build_adapter, discover_adapte
 
 
 SCRIPT_DIR = Path(__file__).parent
+DEFAULT_EXCLUDED_ADAPTERS = {"swift"}
 
 
 class DiffType(str, Enum):
@@ -515,7 +516,10 @@ class VectorRunner:
         """Run all conformance tests."""
         adapters = discover_adapters()
         if adapter_names is None:
-            adapter_names = list(adapters.keys())
+            adapter_names = [
+                name for name in adapters.keys()
+                if name not in DEFAULT_EXCLUDED_ADAPTERS
+            ]
         
         # Auto-discover vector files
         all_vectors = discover_vector_files()
@@ -670,7 +674,7 @@ def main():
         type=str,
         action="append",
         dest="adapters",
-        help="Run only specified adapter(s) - can be used multiple times (typescript, go, rust, python, ruby, java)",
+        help="Run only specified adapter(s) - can be used multiple times (typescript, go, rust, python, ruby, java, swift)",
     )
     parser.add_argument(
         "--vector",


### PR DESCRIPTION
## Summary

- add a SwiftPM-backed Swift adapter for the shared conformance ABI
- keep Swift explicit/opt-in while `tempoxyz/mpp-swift` is private, so default public CI and `make all` do not require private repository access
- wire Swift into targeted setup, local SDK checkout overrides, version reporting, and docs
- verified locally with Swift vectors passing 105/105 and flow conformance passing 30/30