### PR TITLE
test: add Stripe `externalId` binding conformance

### DIFF
--- a/conformance/HARNESS_SPEC.md
+++ b/conformance/HARNESS_SPEC.md
@@ -114,6 +114,7 @@ type AdapterResponse =
           | 'format_error'
           | 'encoding_error'
           | 'generation_error'
+          | 'verification_error'
           | 'http_error'
           | 'unsupported_operation'
           | 'unknown_error'

--- a/conformance/HARNESS_SPEC.md
+++ b/conformance/HARNESS_SPEC.md
@@ -66,6 +66,7 @@ against `schemas/adapter-manifest.schema.json`.
     "base64url.encode",
     "base64url.decode",
     "challenge.id",
+    "stripe.external_id_binding",
     "http.payment_request"
   ]
 }
@@ -173,6 +174,7 @@ Required for vector conformance:
 | `base64url.encode` | `{ "text": string }` | `{ "text": string }` |
 | `base64url.decode` | `{ "text": string }` | `{ "text": string }` |
 | `challenge.id` | challenge id params | `{ "id": string }` |
+| `stripe.external_id_binding` | Stripe request, credential payload, and PaymentIntent fixture | verification outcome |
 
 Required for flow conformance:
 

--- a/conformance/adapters/ruby/Gemfile
+++ b/conformance/adapters/ruby/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
 gem "mpp-rb", "0.1.3"
+gem "bigdecimal"
 gem "sorbet-runtime", "~> 0.6"

--- a/conformance/adapters/ruby/Gemfile
+++ b/conformance/adapters/ruby/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "mpp-rb", "0.1.2"
+gem "mpp-rb", "0.1.3"
 gem "sorbet-runtime", "~> 0.6"

--- a/conformance/adapters/ruby/Gemfile.lock
+++ b/conformance/adapters/ruby/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
+    bigdecimal (4.1.2)
     mpp-rb (0.1.3)
       base64 (~> 0.3)
     sorbet-runtime (0.6.13266)
@@ -13,12 +14,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bigdecimal
   mpp-rb (= 0.1.3)
   sorbet-runtime (~> 0.6)
 
 CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   mpp-rb (0.1.3) sha256=7293528c9ab4bb833853968ba2c32636c6e23a1248898ce32d1c77f9f50dfade
   sorbet-runtime (0.6.13266) sha256=4a7123b62a9174d64a80ec5feae6abbf2d68553cc4c77315c0633b72c9823cc9
 

--- a/conformance/adapters/ruby/Gemfile.lock
+++ b/conformance/adapters/ruby/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
-    mpp-rb (0.1.2)
+    mpp-rb (0.1.3)
       base64 (~> 0.3)
     sorbet-runtime (0.6.13266)
 
@@ -13,13 +13,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  mpp-rb (= 0.1.2)
+  mpp-rb (= 0.1.3)
   sorbet-runtime (~> 0.6)
 
 CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bundler (4.0.12) sha256=7f8b757d28dfb636e7b24fba2344ac6dd13b5b24f4b46d62573d483f211825ac
-  mpp-rb (0.1.2) sha256=fd592ff60d69f3969433bcc8c33e9c3bd02ebcb66e3900bbe69ba8a13d7519ba
+  mpp-rb (0.1.3) sha256=7293528c9ab4bb833853968ba2c32636c6e23a1248898ce32d1c77f9f50dfade
   sorbet-runtime (0.6.13266) sha256=4a7123b62a9174d64a80ec5feae6abbf2d68553cc4c77315c0633b72c9823cc9
 
 BUNDLED WITH

--- a/conformance/adapters/ruby/adapter.json
+++ b/conformance/adapters/ruby/adapter.json
@@ -22,6 +22,7 @@
     "receipt.format",
     "base64url.encode",
     "base64url.decode",
-    "challenge.id"
+    "challenge.id",
+    "stripe.external_id_binding"
   ]
 }

--- a/conformance/adapters/ruby/adapter.rb
+++ b/conformance/adapters/ruby/adapter.rb
@@ -154,7 +154,8 @@ OP_TO_COMMAND = {
   "receipt.format" => "format-receipt",
   "base64url.encode" => "base64url-encode",
   "base64url.decode" => "base64url-decode",
-  "challenge.id" => "generate-challenge-id"
+  "challenge.id" => "generate-challenge-id",
+  "stripe.external_id_binding" => "verify-stripe-external-id-binding"
 }.freeze
 
 def command_input_for_request(op, input)
@@ -170,6 +171,82 @@ def response_value_for_operation(op, result)
   return {id: result} if op == "challenge.id"
 
   result
+end
+
+class ConformanceStripeClient
+  def initialize(input)
+    @input = input
+  end
+
+  def v1
+    Struct.new(:payment_intents).new(ConformancePaymentIntents.new(@input))
+  end
+end
+
+class ConformancePaymentIntents
+  def initialize(input)
+    @input = input
+  end
+
+  def create(params, _opts)
+    raise "Unexpected shared_payment_granted_token" unless params[:shared_payment_granted_token] == @input.fetch("payload").fetch("spt")
+
+    payment_intent = @input.fetch("paymentIntent")
+    headers = payment_intent["replayed"] ? {"idempotent-replayed" => "true"} : {}
+    last_response = Struct.new(:headers).new(headers)
+    Struct.new(:id, :status, :last_response).new(
+      payment_intent.fetch("id"),
+      payment_intent.fetch("status"),
+      last_response
+    )
+  end
+end
+
+def verify_stripe_external_id_binding(input)
+  require "mpp/methods/stripe"
+  require "mpp/server"
+
+  secret_key = "conformance-stripe-secret"
+  realm = "conformance.local"
+  expires = "2099-01-29T12:05:30Z"
+  challenge = Mpp::Challenge.create(
+    secret_key: secret_key,
+    realm: realm,
+    method: "stripe",
+    intent: "charge",
+    request: input.fetch("request"),
+    expires: expires
+  )
+  credential = Mpp::Credential.new(challenge: challenge.to_echo, payload: input.fetch("payload"))
+  intent = Mpp::Methods::Stripe::ChargeIntent.new(
+    secret_key: "sk_test_conformance",
+    client: ConformanceStripeClient.new(input)
+  )
+
+  verified = Mpp::Server::Verify.verify_or_challenge(
+    authorization: credential.to_authorization,
+    intent: intent,
+    request: input.fetch("request"),
+    realm: realm,
+    secret_key: secret_key,
+    method: "stripe",
+    expires: expires
+  )
+  return {ok: false, errorType: "invalid_challenge"} if verified.is_a?(Mpp::Challenge)
+
+  _credential, receipt = verified
+  receipt_payload = {
+    status: receipt.status,
+    method: receipt.method,
+    timestamp: "2026-01-29T12:00:30Z",
+    reference: receipt.reference
+  }
+  receipt_payload[:externalId] = receipt.external_id unless receipt.external_id.nil?
+  {ok: true, receipt: receipt_payload}
+rescue Mpp::InvalidChallengeError
+  {ok: false, errorType: "invalid_challenge"}
+rescue Mpp::VerificationError, Mpp::PaymentError, StandardError
+  {ok: false, errorType: "verification_failed"}
 end
 
 def run_adapter_request(request)
@@ -197,6 +274,8 @@ def error_type_for_command(command)
     "encoding_error"
   elsif command.start_with?("generate-")
     "generation_error"
+  elsif command.start_with?("verify-")
+    "verification_error"
   else
     "unknown_error"
   end
@@ -238,6 +317,8 @@ def run_command(command, input)
     success(base64url_decode(input).force_encoding("UTF-8"))
   when "generate-challenge-id"
     success(generate_conformance_challenge_id(JSON.parse(input)))
+  when "verify-stripe-external-id-binding"
+    success(verify_stripe_external_id_binding(JSON.parse(input)))
   else
     error("Unknown command: #{command}")
   end

--- a/conformance/adapters/typescript/adapter.json
+++ b/conformance/adapters/typescript/adapter.json
@@ -18,6 +18,7 @@
     "receipt.format",
     "base64url.encode",
     "base64url.decode",
-    "challenge.id"
+    "challenge.id",
+    "stripe.external_id_binding"
   ]
 }

--- a/conformance/examples/adapter.json
+++ b/conformance/examples/adapter.json
@@ -16,6 +16,7 @@
     "base64url.encode",
     "base64url.decode",
     "challenge.id",
+    "stripe.external_id_binding",
     "http.payment_request"
   ]
 }

--- a/conformance/examples/stripe-external-id-binding.request.json
+++ b/conformance/examples/stripe-external-id-binding.request.json
@@ -1,0 +1,26 @@
+{
+  "schema": 1,
+  "op": "stripe.external_id_binding",
+  "input": {
+    "request": {
+      "amount": "2500",
+      "currency": "USD",
+      "externalId": "server-order-123",
+      "methodDetails": {
+        "paymentMethodTypes": ["card"]
+      }
+    },
+    "payload": {
+      "spt": "spt_conformance_123",
+      "externalId": "server-order-123"
+    },
+    "paymentIntent": {
+      "id": "pi_conformance_123",
+      "status": "succeeded"
+    }
+  },
+  "context": {
+    "vectorName": "stripe-external-id-binding",
+    "caseName": "matching_external_id_returns_bound_receipt"
+  }
+}

--- a/conformance/examples/stripe-external-id-binding.response.json
+++ b/conformance/examples/stripe-external-id-binding.response.json
@@ -1,0 +1,13 @@
+{
+  "ok": true,
+  "value": {
+    "ok": true,
+    "receipt": {
+      "status": "success",
+      "method": "stripe",
+      "timestamp": "2026-01-29T12:00:30Z",
+      "reference": "pi_conformance_123",
+      "externalId": "server-order-123"
+    }
+  }
+}

--- a/conformance/golden/adapter.ts
+++ b/conformance/golden/adapter.ts
@@ -41,6 +41,7 @@ interface ErrorResult {
 		| 'format_error'
 		| 'encoding_error'
 		| 'generation_error'
+		| 'verification_error'
 		| 'unsupported_operation'
 		| 'unknown_error'
 }
@@ -124,6 +125,46 @@ function generateConformanceChallengeId(params: {
 	return createHmac('sha256', params.secretKey).update(payload).digest('base64url')
 }
 
+function verifyStripeExternalIdBinding(input: {
+	request: Record<string, unknown>
+	payload: Record<string, unknown>
+	paymentIntent: { id: string; status: string; replayed?: boolean }
+}): {
+	ok: true
+	receipt: {
+		status: string
+		method: string
+		timestamp: string
+		reference: string
+		externalId?: string
+	}
+} | { ok: false; errorType: 'invalid_challenge' | 'verification_failed' } {
+	const requestExternalId = input.request.externalId
+	const payloadExternalId = input.payload.externalId
+
+	if (typeof input.payload.spt !== 'string' || input.payload.spt.length === 0)
+		return { ok: false, errorType: 'verification_failed' }
+	if (input.paymentIntent.replayed || input.paymentIntent.status !== 'succeeded')
+		return { ok: false, errorType: 'verification_failed' }
+	if (payloadExternalId !== undefined && typeof payloadExternalId !== 'string')
+		return { ok: false, errorType: 'invalid_challenge' }
+	if (requestExternalId !== undefined && typeof requestExternalId !== 'string')
+		return { ok: false, errorType: 'invalid_challenge' }
+	if (requestExternalId !== undefined && payloadExternalId !== requestExternalId)
+		return { ok: false, errorType: 'invalid_challenge' }
+
+	return {
+		ok: true,
+		receipt: {
+			status: 'success',
+			method: 'stripe',
+			timestamp: '2026-01-29T12:00:30Z',
+			reference: input.paymentIntent.id,
+			...(requestExternalId ? { externalId: requestExternalId } : {}),
+		},
+	}
+}
+
 function hasDuplicateChallengeParameter(header: string): boolean {
 	const seen = new Set<string>()
 	for (const match of header.matchAll(/(?:^|,\s*)(\w+)=/g)) {
@@ -191,6 +232,11 @@ function runCommand(command: string, input: string): Result<unknown> {
 				return success(generateConformanceChallengeId(params))
 			}
 
+			case 'verify-stripe-external-id-binding': {
+				const params = JSON.parse(input)
+				return success(verifyStripeExternalIdBinding(params))
+			}
+
 			default:
 				return error(`Unknown command: ${command}`, 'unknown_error')
 		}
@@ -205,6 +251,8 @@ function runCommand(command: string, input: string): Result<unknown> {
 			return error(message, 'encoding_error')
 		} else if (command.startsWith('generate-')) {
 			return error(message, 'generation_error')
+		} else if (command.startsWith('verify-')) {
+			return error(message, 'verification_error')
 		} else {
 			return error(message, 'unknown_error')
 		}
@@ -221,6 +269,7 @@ const OP_TO_COMMAND: Record<string, string> = {
 	'base64url.encode': 'base64url-encode',
 	'base64url.decode': 'base64url-decode',
 	'challenge.id': 'generate-challenge-id',
+	'stripe.external_id_binding': 'verify-stripe-external-id-binding',
 }
 
 function commandInputForRequest(op: string, input: unknown): string {

--- a/conformance/golden/adapter.ts
+++ b/conformance/golden/adapter.ts
@@ -27,6 +27,7 @@
 import { createHmac } from 'node:crypto'
 
 import { Challenge, Credential, Receipt } from 'mppx'
+import { Mppx, stripe } from 'mppx/server'
 
 interface SuccessResult<T> {
 	success: true
@@ -125,43 +126,86 @@ function generateConformanceChallengeId(params: {
 	return createHmac('sha256', params.secretKey).update(payload).digest('base64url')
 }
 
-function verifyStripeExternalIdBinding(input: {
+async function verifyStripeExternalIdBinding(input: {
 	request: Record<string, unknown>
 	payload: Record<string, unknown>
 	paymentIntent: { id: string; status: string; replayed?: boolean }
-}): {
-	ok: true
-	receipt: {
-		status: string
-		method: string
-		timestamp: string
-		reference: string
-		externalId?: string
-	}
-} | { ok: false; errorType: 'invalid_challenge' | 'verification_failed' } {
-	const requestExternalId = input.request.externalId
-	const payloadExternalId = input.payload.externalId
-
-	if (typeof input.payload.spt !== 'string' || input.payload.spt.length === 0)
-		return { ok: false, errorType: 'verification_failed' }
-	if (input.paymentIntent.replayed || input.paymentIntent.status !== 'succeeded')
-		return { ok: false, errorType: 'verification_failed' }
-	if (payloadExternalId !== undefined && typeof payloadExternalId !== 'string')
-		return { ok: false, errorType: 'invalid_challenge' }
-	if (requestExternalId !== undefined && typeof requestExternalId !== 'string')
-		return { ok: false, errorType: 'invalid_challenge' }
-	if (requestExternalId !== undefined && payloadExternalId !== requestExternalId)
-		return { ok: false, errorType: 'invalid_challenge' }
-
-	return {
-		ok: true,
+}): Promise<
+	| {
+		ok: true
 		receipt: {
-			status: 'success',
-			method: 'stripe',
-			timestamp: '2026-01-29T12:00:30Z',
-			reference: input.paymentIntent.id,
-			...(requestExternalId ? { externalId: requestExternalId } : {}),
-		},
+			status: string
+			method: string
+			timestamp: string
+			reference: string
+			externalId?: string
+		}
+	}
+	| { ok: false; errorType: 'invalid_challenge' | 'verification_failed' }
+> {
+	const secretKey = 'conformance-stripe-secret'
+	const methodDetails =
+		typeof input.request.methodDetails === 'object' && input.request.methodDetails !== null
+			? (input.request.methodDetails as Record<string, unknown>)
+			: {}
+	const mppx = Mppx.create({
+		secretKey,
+		methods: [
+			stripe.charge({
+				amount: String(input.request.amount ?? '0'),
+				client: {
+					paymentIntents: {
+						async create(params: Record<string, unknown>) {
+							if (params.shared_payment_granted_token !== input.payload.spt) {
+								throw new Error('Unexpected shared_payment_granted_token')
+							}
+							return {
+								id: input.paymentIntent.id,
+								status: input.paymentIntent.status,
+								lastResponse: {
+									headers: {
+										...(input.paymentIntent.replayed
+											? { 'idempotent-replayed': 'true' }
+											: {}),
+									},
+								},
+							}
+						},
+					},
+				},
+				currency: String(input.request.currency ?? 'usd'),
+				decimals: 0,
+				networkId:
+					typeof methodDetails.networkId === 'string' ? methodDetails.networkId : 'conformance',
+				paymentMethodTypes: Array.isArray(methodDetails.paymentMethodTypes)
+					? methodDetails.paymentMethodTypes.map(String)
+					: ['card'],
+			}),
+		],
+	})
+	const challenge = Challenge.from({
+		secretKey,
+		realm: 'conformance.local',
+		method: 'stripe',
+		intent: 'charge',
+		request: input.request,
+		expires: '2099-01-29T12:05:30Z',
+	})
+	const credential = Credential.from({ challenge, payload: input.payload })
+
+	try {
+		const receipt = await mppx.verifyCredential(credential)
+		return {
+			ok: true,
+			receipt: {
+				...receipt,
+				timestamp: '2026-01-29T12:00:30Z',
+			},
+		}
+	} catch (err) {
+		if (err instanceof Error && err.name === 'InvalidChallengeError')
+			return { ok: false, errorType: 'invalid_challenge' }
+		return { ok: false, errorType: 'verification_failed' }
 	}
 }
 
@@ -175,7 +219,7 @@ function hasDuplicateChallengeParameter(header: string): boolean {
 	return false
 }
 
-function runCommand(command: string, input: string): Result<unknown> {
+async function runCommand(command: string, input: string): Promise<Result<unknown>> {
 	try {
 		switch (command) {
 			case 'parse-www-authenticate': {
@@ -234,7 +278,7 @@ function runCommand(command: string, input: string): Result<unknown> {
 
 			case 'verify-stripe-external-id-binding': {
 				const params = JSON.parse(input)
-				return success(verifyStripeExternalIdBinding(params))
+				return success(await verifyStripeExternalIdBinding(params))
 			}
 
 			default:
@@ -285,13 +329,13 @@ function responseValueForOperation(op: string, result: unknown): unknown {
 	return result
 }
 
-function runAdapterRequest(request: { op: string; input: unknown }): AdapterResponse {
+async function runAdapterRequest(request: { op: string; input: unknown }): Promise<AdapterResponse> {
 	if (request.op === 'http.payment_request') {
 		return adapterError('http.payment_request is not implemented by this adapter yet', 'unsupported_operation')
 	}
 	const command = OP_TO_COMMAND[request.op]
 	if (!command) return adapterError(`Unknown operation: ${request.op}`, 'unsupported_operation')
-	const result = runCommand(command, commandInputForRequest(request.op, request.input))
+	const result = await runCommand(command, commandInputForRequest(request.op, request.input))
 	if (!result.success) return adapterError(result.error, result.error_type)
 	return adapterSuccess(responseValueForOperation(request.op, result.result))
 }
@@ -302,12 +346,12 @@ async function main(): Promise<void> {
 	if (!command) {
 		const stdin = await readStdin()
 		const request = JSON.parse(stdin)
-		console.log(JSON.stringify(runAdapterRequest(request)))
+		console.log(JSON.stringify(await runAdapterRequest(request)))
 		return
 	}
 
 	const stdin = await readStdin()
-	const result = runCommand(command, stdin)
+	const result = await runCommand(command, stdin)
 	console.log(JSON.stringify(result))
 }
 

--- a/conformance/operations.json
+++ b/conformance/operations.json
@@ -74,6 +74,14 @@
       "comparison": "exact",
       "description": "Generate a deterministic challenge id from canonical challenge id parameters."
     },
+    "stripe.external_id_binding": {
+      "category": "vector",
+      "inputRef": "protocol.schema.json#/$defs/StripeExternalIdBindingInput",
+      "successRef": "protocol.schema.json#/$defs/StripeExternalIdBindingResult",
+      "errorTypes": ["verification_error"],
+      "comparison": "exact",
+      "description": "Verify Stripe charge receipt attribution uses only the server-bound request externalId and cannot be forged from credential payload."
+    },
     "http.payment_request": {
       "category": "flow",
       "inputRef": "protocol.schema.json#/$defs/HttpPaymentRequest",

--- a/conformance/package-lock.json
+++ b/conformance/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "mppx": "0.6.29"
+        "mppx": "0.7.0"
       },
       "devDependencies": {
         "@types/node": "^25.9.1",
@@ -578,6 +578,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@stripe/stripe-js": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-9.7.0.tgz",
+      "integrity": "sha512-r1ElolvWXM4aYnZZVHvKW3EDL8JcwEuIgTuWxlB5lvC+YsvjkQ0gX35x9d8dTDubX395fViLVqkaolVs1PmIQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
+    },
     "node_modules/@toon-format/toon": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-2.3.0.tgz",
@@ -679,9 +688,9 @@
       }
     },
     "node_modules/incur": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/incur/-/incur-0.4.6.tgz",
-      "integrity": "sha512-vrvmmZmfhU0OOm+KuofBClaYaioJ0JrxPn89Zfp8TDfXOBgWsDXqX5QgZS6FItvizqXEuzaoNiBiRgC5vJazDg==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/incur/-/incur-0.4.8.tgz",
+      "integrity": "sha512-SjW2QNtY7Bcvqjj0KvOJ3qiuFATlC3mEpYQyUzWdLb9MAzakkQ1KQg5WZ/yy2tDGBmHLN/zUJNimIWEqkRfqdw==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.1.1",
@@ -717,13 +726,14 @@
       }
     },
     "node_modules/mppx": {
-      "version": "0.6.29",
-      "resolved": "https://registry.npmjs.org/mppx/-/mppx-0.6.29.tgz",
-      "integrity": "sha512-Qi/F/fZV0WZyklm2pY1ipAt+zQQsHuuA7DBhsvrHxxQAAZmWIVWmIujc7ebqawiOqlkuR2SQ3VOs7TqZYFiQxA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/mppx/-/mppx-0.7.0.tgz",
+      "integrity": "sha512-qOHQjD75wSHSZeXutngPXou8NEMIOw6RhZ/lQbo2JmDQWfOi40pLGpqXgHgwIjw4YcJHClFsI7mFXBK3Nj5WCQ==",
       "license": "MIT",
       "dependencies": {
-        "incur": "^0.4.5",
-        "ox": "0.14.24",
+        "@stripe/stripe-js": "9.7.0",
+        "incur": "^0.4.8",
+        "ox": "0.14.27",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -753,9 +763,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.24",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.24.tgz",
-      "integrity": "sha512-mviaFeN/cSkj/1B7EJKB3fYzQ4E3y7CDmR7Iqei1QUT0M1Zkuo0kNI/ewBnShf7h5r57gp68/DFltjNu5HJCYQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.27.tgz",
+      "integrity": "sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==",
       "funding": [
         {
           "type": "github",
@@ -877,37 +887,6 @@
           "optional": true
         },
         "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/viem/node_modules/ox": {
-      "version": "0.14.27",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.27.tgz",
-      "integrity": "sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.2.3",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
           "optional": true
         }
       }

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -17,7 +17,7 @@
     "build:all": "make install"
   },
   "dependencies": {
-    "mppx": "0.6.29"
+    "mppx": "0.7.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",

--- a/conformance/schemas/adapter-request.schema.json
+++ b/conformance/schemas/adapter-request.schema.json
@@ -57,6 +57,10 @@
       "then": { "properties": { "input": { "$ref": "protocol.schema.json#/$defs/ChallengeIdInput" } } }
     },
     {
+      "if": { "properties": { "op": { "const": "stripe.external_id_binding" } }, "required": ["op"] },
+      "then": { "properties": { "input": { "$ref": "protocol.schema.json#/$defs/StripeExternalIdBindingInput" } } }
+    },
+    {
       "if": { "properties": { "op": { "const": "http.payment_request" } }, "required": ["op"] },
       "then": { "properties": { "input": { "$ref": "protocol.schema.json#/$defs/HttpPaymentRequest" } } }
     }

--- a/conformance/schemas/protocol.schema.json
+++ b/conformance/schemas/protocol.schema.json
@@ -15,6 +15,7 @@
         "base64url.encode",
         "base64url.decode",
         "challenge.id",
+        "stripe.external_id_binding",
         "http.payment_request"
       ]
     },
@@ -25,6 +26,7 @@
         "format_error",
         "encoding_error",
         "generation_error",
+        "verification_error",
         "http_error",
         "unsupported_operation",
         "unknown_error"
@@ -126,6 +128,47 @@
       "properties": {
         "id": { "type": "string", "minLength": 1 }
       }
+    },
+    "StripeExternalIdBindingInput": {
+      "type": "object",
+      "required": ["request", "payload", "paymentIntent"],
+      "additionalProperties": false,
+      "properties": {
+        "request": { "$ref": "#/$defs/JsonObject" },
+        "payload": { "$ref": "#/$defs/JsonObject" },
+        "paymentIntent": {
+          "type": "object",
+          "required": ["id", "status"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "status": { "type": "string", "minLength": 1 },
+            "replayed": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "StripeExternalIdBindingResult": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["ok", "receipt"],
+          "additionalProperties": false,
+          "properties": {
+            "ok": { "const": true },
+            "receipt": { "$ref": "#/$defs/Receipt" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["ok", "errorType"],
+          "additionalProperties": false,
+          "properties": {
+            "ok": { "const": false },
+            "errorType": { "enum": ["invalid_challenge", "verification_failed"] }
+          }
+        }
+      ]
     },
     "HttpPaymentMode": {
       "type": "string",

--- a/conformance/scripts/harness.py
+++ b/conformance/scripts/harness.py
@@ -26,6 +26,7 @@ COMMAND_TO_OPERATION = {
     "base64url-encode": "base64url.encode",
     "base64url-decode": "base64url.decode",
     "generate-challenge-id": "challenge.id",
+    "verify-stripe-external-id-binding": "stripe.external_id_binding",
 }
 
 
@@ -126,7 +127,13 @@ def request_input_for_command(command: str, input_data: str) -> tuple[str, Any]:
     op = COMMAND_TO_OPERATION[command]
     if op in {"challenge.parse", "credential.parse", "receipt.parse"}:
         return op, {"header": input_data}
-    if op in {"challenge.format", "credential.format", "receipt.format", "challenge.id"}:
+    if op in {
+        "challenge.format",
+        "credential.format",
+        "receipt.format",
+        "challenge.id",
+        "stripe.external_id_binding",
+    }:
         return op, json.loads(input_data)
     if op in {"base64url.encode", "base64url.decode"}:
         return op, {"text": input_data}

--- a/conformance/vectors/stripe-external-id-binding.json
+++ b/conformance/vectors/stripe-external-id-binding.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "spec_ref": "draft-ietf-httpauth-payment §5.1.1",
+  "spec_ref": "draft-ietf-httpauth-payment challenge-id HMAC binding; draft-stripe-charge externalId receipt attribution",
   "description": "Stripe charge receipt externalId attribution must come from the server-bound request and cannot be forged from credential payload.",
   "commands": {
     "generate": "verify-stripe-external-id-binding"
@@ -9,8 +9,8 @@
     {
       "name": "matching_external_id_returns_bound_receipt",
       "description": "A credential whose payload externalId matches the server-bound request externalId returns a receipt attributed to that externalId.",
-      "tags": ["happy-path", "stripe", "metadata-binding"],
-      "adapters": ["typescript"],
+      "tags": ["happy-path", "stripe", "external-id-binding"],
+      "adapters": ["typescript", "ruby"],
       "input": {
         "request": {
           "amount": "2500",
@@ -43,8 +43,8 @@
     {
       "name": "forged_payload_external_id_rejected",
       "description": "A credential payload cannot replace the externalId that was bound into the server request.",
-      "tags": ["error", "stripe", "metadata-binding"],
-      "adapters": ["typescript"],
+      "tags": ["error", "stripe", "external-id-binding"],
+      "adapters": ["typescript", "ruby"],
       "input": {
         "request": {
           "amount": "2500",
@@ -71,8 +71,8 @@
     {
       "name": "payload_only_external_id_not_attributed",
       "description": "A payload externalId is ignored when no externalId was bound into the server request.",
-      "tags": ["happy-path", "stripe", "metadata-binding"],
-      "adapters": ["typescript"],
+      "tags": ["happy-path", "stripe", "external-id-binding"],
+      "adapters": ["typescript", "ruby"],
       "input": {
         "request": {
           "amount": "2500",
@@ -103,8 +103,8 @@
     {
       "name": "missing_payload_external_id_rejected_when_request_bound",
       "description": "A request-bound externalId must be echoed by the credential payload so stripped attribution cannot settle silently.",
-      "tags": ["error", "stripe", "metadata-binding"],
-      "adapters": ["typescript"],
+      "tags": ["error", "stripe", "external-id-binding"],
+      "adapters": ["typescript", "ruby"],
       "input": {
         "request": {
           "amount": "2500",
@@ -125,6 +125,35 @@
       "expected": {
         "ok": false,
         "errorType": "invalid_challenge"
+      }
+    },
+    {
+      "name": "replayed_payment_intent_rejected",
+      "description": "A replayed Stripe PaymentIntent response cannot satisfy a request-bound externalId challenge.",
+      "tags": ["error", "stripe", "external-id-binding"],
+      "adapters": ["typescript", "ruby"],
+      "input": {
+        "request": {
+          "amount": "2500",
+          "currency": "USD",
+          "externalId": "server-order-123",
+          "methodDetails": {
+            "paymentMethodTypes": ["card"]
+          }
+        },
+        "payload": {
+          "spt": "spt_conformance_123",
+          "externalId": "server-order-123"
+        },
+        "paymentIntent": {
+          "id": "pi_conformance_123",
+          "status": "succeeded",
+          "replayed": true
+        }
+      },
+      "expected": {
+        "ok": false,
+        "errorType": "verification_failed"
       }
     }
   ]

--- a/conformance/vectors/stripe-external-id-binding.json
+++ b/conformance/vectors/stripe-external-id-binding.json
@@ -1,0 +1,131 @@
+{
+  "version": "1.0.0",
+  "spec_ref": "draft-ietf-httpauth-payment §5.1.1",
+  "description": "Stripe charge receipt externalId attribution must come from the server-bound request and cannot be forged from credential payload.",
+  "commands": {
+    "generate": "verify-stripe-external-id-binding"
+  },
+  "scenarios": [
+    {
+      "name": "matching_external_id_returns_bound_receipt",
+      "description": "A credential whose payload externalId matches the server-bound request externalId returns a receipt attributed to that externalId.",
+      "tags": ["happy-path", "stripe", "metadata-binding"],
+      "adapters": ["typescript"],
+      "input": {
+        "request": {
+          "amount": "2500",
+          "currency": "USD",
+          "externalId": "server-order-123",
+          "methodDetails": {
+            "paymentMethodTypes": ["card"]
+          }
+        },
+        "payload": {
+          "spt": "spt_conformance_123",
+          "externalId": "server-order-123"
+        },
+        "paymentIntent": {
+          "id": "pi_conformance_123",
+          "status": "succeeded"
+        }
+      },
+      "expected": {
+        "ok": true,
+        "receipt": {
+          "status": "success",
+          "method": "stripe",
+          "timestamp": "2026-01-29T12:00:30Z",
+          "reference": "pi_conformance_123",
+          "externalId": "server-order-123"
+        }
+      }
+    },
+    {
+      "name": "forged_payload_external_id_rejected",
+      "description": "A credential payload cannot replace the externalId that was bound into the server request.",
+      "tags": ["error", "stripe", "metadata-binding"],
+      "adapters": ["typescript"],
+      "input": {
+        "request": {
+          "amount": "2500",
+          "currency": "USD",
+          "externalId": "server-order-123",
+          "methodDetails": {
+            "paymentMethodTypes": ["card"]
+          }
+        },
+        "payload": {
+          "spt": "spt_conformance_123",
+          "externalId": "attacker-order-999"
+        },
+        "paymentIntent": {
+          "id": "pi_conformance_123",
+          "status": "succeeded"
+        }
+      },
+      "expected": {
+        "ok": false,
+        "errorType": "invalid_challenge"
+      }
+    },
+    {
+      "name": "payload_only_external_id_not_attributed",
+      "description": "A payload externalId is ignored when no externalId was bound into the server request.",
+      "tags": ["happy-path", "stripe", "metadata-binding"],
+      "adapters": ["typescript"],
+      "input": {
+        "request": {
+          "amount": "2500",
+          "currency": "USD",
+          "methodDetails": {
+            "paymentMethodTypes": ["card"]
+          }
+        },
+        "payload": {
+          "spt": "spt_conformance_123",
+          "externalId": "attacker-order-999"
+        },
+        "paymentIntent": {
+          "id": "pi_conformance_123",
+          "status": "succeeded"
+        }
+      },
+      "expected": {
+        "ok": true,
+        "receipt": {
+          "status": "success",
+          "method": "stripe",
+          "timestamp": "2026-01-29T12:00:30Z",
+          "reference": "pi_conformance_123"
+        }
+      }
+    },
+    {
+      "name": "missing_payload_external_id_rejected_when_request_bound",
+      "description": "A request-bound externalId must be echoed by the credential payload so stripped attribution cannot settle silently.",
+      "tags": ["error", "stripe", "metadata-binding"],
+      "adapters": ["typescript"],
+      "input": {
+        "request": {
+          "amount": "2500",
+          "currency": "USD",
+          "externalId": "server-order-123",
+          "methodDetails": {
+            "paymentMethodTypes": ["card"]
+          }
+        },
+        "payload": {
+          "spt": "spt_conformance_123"
+        },
+        "paymentIntent": {
+          "id": "pi_conformance_123",
+          "status": "succeeded"
+        }
+      },
+      "expected": {
+        "ok": false,
+        "errorType": "invalid_challenge"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds Stripe `externalId` binding conformance to close OSS-324.

## Changes
- Adds `stripe.external_id_binding` operation, schemas, examples, and harness docs.
- Adds golden TypeScript adapter support.
- Adds vectors covering valid attribution, forged payload `externalId`, payload-only injection, and stripped payload attribution.