### PR TITLE
conformance(www-authenticate): quoted-value Payment keyword vectors

### DIFF
--- a/conformance/vectors/www-authenticate.json
+++ b/conformance/vectors/www-authenticate.json
@@ -139,6 +139,39 @@
       }
     },
     {
+      "name": "payment_keyword_in_quoted_realm",
+      "description": "The word 'Payment' inside a quoted parameter value must not be mistaken for a second auth scheme",
+      "tags": ["happy-path", "edge-case", "quoted-string", "scheme-boundary"],
+      "object": {
+        "id": "ch_qp_realm",
+        "intent": "charge",
+        "method": "tempo",
+        "realm": "contact Payment support",
+        "request": {}
+      },
+      "wire": "Payment id=\"ch_qp_realm\", realm=\"contact Payment support\", method=\"tempo\", intent=\"charge\", request=\"e30\"",
+      "tests": {
+        "parse": true
+      }
+    },
+    {
+      "name": "payment_keyword_in_quoted_description",
+      "description": "A quoted description containing 'Payment' is parsed as an opaque value, not a scheme boundary",
+      "tags": ["happy-path", "edge-case", "quoted-string", "scheme-boundary"],
+      "object": {
+        "description": "Pay with the Payment scheme",
+        "id": "ch_qp_desc",
+        "intent": "charge",
+        "method": "tempo",
+        "realm": "api.example.com",
+        "request": {}
+      },
+      "wire": "Payment id=\"ch_qp_desc\", realm=\"api.example.com\", method=\"tempo\", intent=\"charge\", request=\"e30\", description=\"Pay with the Payment scheme\"",
+      "tests": {
+        "parse": true
+      }
+    },
+    {
       "name": "adversarial_unclosed_quoted_extension",
       "description": "Malformed quoted extension auth-param with many escapes is ignored without pathological parser backtracking",
       "tags": ["happy-path", "edge-case", "quoted-string", "performance", "oss-319"],


### PR DESCRIPTION
## What this adds

Two parse scenarios to `conformance/vectors/www-authenticate.json` asserting that the literal word `Payment` appearing inside a quoted parameter value is treated as an opaque string, not a second auth scheme or a scheme boundary:

- `payment_keyword_in_quoted_realm` — `realm="contact Payment support"`
- `payment_keyword_in_quoted_description` — `description="Pay with the Payment scheme"`

Both are happy-path parses: the challenge decodes with the full quoted value intact.

## Why

A merged or proxy-rewritten `WWW-Authenticate` header can carry the word `Payment` inside a quoted parameter, and a parser that scans for the scheme name without respecting quoted strings can mis-detect a boundary and pick the wrong challenge (or none). This is the behaviour fixed in stripe/mpp-rb#11; these vectors codify it as cross-SDK truth so every adapter is held to it.

They sit in the same family as the existing `escaped_quotes_in_description` / `unescaped_quotes_in_description` scenarios (quoted values are opaque), so conformant parsers already satisfy them.

## Verification

`python3 scripts/vector_runner.py --adapter python --vector www-authenticate` -> 32 passed, 32 total (the two new vectors included). Diff is additive only (no reformatting of existing scenarios).

## Note

A companion concern from the same review (stripe/mpp-rb#14, stricter rejection of malformed auth-params) is intentionally NOT added here: the SDKs are not yet aligned on malformed-param strictness (the Python parser is currently lenient where Ruby now rejects), so a rejection vector would need that cross-SDK alignment first. Happy to follow up with it once the implementations converge.


---

### Review by GPT-5.5 (xhigh, via Codex)

> The change only adds two focused WWW-Authenticate parse vectors for quoted values containing the Payment token. I found no actionable correctness issue in the added scenarios.

Codex independently re-ran the python adapter on the new `scheme-boundary` tag (`vector_runner.py --tag scheme-boundary`): 2/2 pass.
