### PR TITLE
test: add payment hardening conformance checks

### DIFF
--- a/conformance/adapters/go/main.go
+++ b/conformance/adapters/go/main.go
@@ -38,6 +38,8 @@ type adapterResponse struct {
 	Error *adapterError `json:"error,omitempty"`
 }
 
+const minimumSecretKeyBytes = 32
+
 type adapterError struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
@@ -227,7 +229,7 @@ func handleGenerateChallengeID(input string) {
 		return
 	}
 
-	result := generateConformanceChallengeID(
+	result, err := generateConformanceChallengeID(
 		stringField(data, "secretKey"),
 		stringField(data, "realm"),
 		stringField(data, "method"),
@@ -237,6 +239,10 @@ func handleGenerateChallengeID(input string) {
 		stringField(data, "digest"),
 		stringField(data, "opaque"),
 	)
+	if err != nil {
+		printJSON(commandResponse{Success: false, Error: err.Error(), ErrorType: "generation_error"})
+		return
+	}
 	printJSON(commandResponse{Success: true, Result: result})
 }
 
@@ -530,7 +536,11 @@ func parseConformanceReceipt(header string) (*mpp.Receipt, error) {
 // string placed directly in the pipe-delimited HMAC input, which differs from
 // the library's map[string]string encoding. Once the spec settles on a single
 // encoding this can be replaced with mpp.GenerateChallengeID.
-func generateConformanceChallengeID(secretKey, realm, method, intent string, request map[string]any, expires, digest, opaque string) string {
+func generateConformanceChallengeID(secretKey, realm, method, intent string, request map[string]any, expires, digest, opaque string) (string, error) {
+	if len([]byte(secretKey)) < minimumSecretKeyBytes {
+		return "", fmt.Errorf("secretKey must be at least %d bytes", minimumSecretKeyBytes)
+	}
+
 	requestB64, _ := encodeJSONBase64URL(request)
 
 	input := strings.Join([]string{
@@ -546,7 +556,7 @@ func generateConformanceChallengeID(secretKey, realm, method, intent string, req
 	mac := hmac.New(sha256.New, []byte(secretKey))
 	mac.Write([]byte(input))
 
-	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), nil
 }
 
 func formatConformanceReceipt(receipt *mpp.Receipt) (string, error) {

--- a/conformance/adapters/java/src/main/java/xyz/tempo/mpp/conformance/Adapter.java
+++ b/conformance/adapters/java/src/main/java/xyz/tempo/mpp/conformance/Adapter.java
@@ -29,6 +29,8 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 public final class Adapter {
+    private static final int MINIMUM_SECRET_KEY_BYTES = 32;
+
     private static final Pattern AUTH_PARAM = Pattern.compile(
         "(\\w+)=(?:\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\"|([^\\s,]+))"
     );
@@ -320,6 +322,10 @@ public final class Adapter {
 
     private static String generateChallengeId(Map<String, Object> data) throws AdapterFailure {
         String secretKey = requiredString(data, "secretKey", "generation_error", false);
+        if (secretKey.getBytes(StandardCharsets.UTF_8).length < MINIMUM_SECRET_KEY_BYTES) {
+            throw new AdapterFailure("generation_error", "secretKey must be at least " + MINIMUM_SECRET_KEY_BYTES + " bytes");
+        }
+
         Map<String, Object> request = requireMap(data.get("request"), "request", "generation_error");
         String expires = optionalString(data, "expires", "generation_error");
         String digest = optionalString(data, "digest", "generation_error");

--- a/conformance/adapters/python/adapter.py
+++ b/conformance/adapters/python/adapter.py
@@ -23,6 +23,8 @@ from mpp import (
     format_payment_receipt,
 )
 
+MINIMUM_SECRET_KEY_BYTES = 32
+
 
 def base64url_encode(data: str) -> str:
     """Encode a string to base64url without padding."""
@@ -55,6 +57,9 @@ def canonical_json(value) -> str:
 
 
 def generate_conformance_challenge_id(*, secret_key: str, realm: str, method: str, intent: str, request, expires: str | None = None, digest: str | None = None, opaque: str | None = None) -> str:
+    if len(secret_key.encode("utf-8")) < MINIMUM_SECRET_KEY_BYTES:
+        raise ValueError(f"secretKey must be at least {MINIMUM_SECRET_KEY_BYTES} bytes")
+
     request_b64 = base64.urlsafe_b64encode(canonical_json(request or {}).encode("utf-8")).decode("ascii").rstrip("=")
     payload = "|".join([
         realm,

--- a/conformance/adapters/ruby/adapter.rb
+++ b/conformance/adapters/ruby/adapter.rb
@@ -10,6 +10,8 @@ require "time"
 require "mpp-rb"
 require "mpp/methods/tempo"
 
+MINIMUM_SECRET_KEY_BYTES = 32
+
 def success(result)
   {success: true, result: result}
 end
@@ -55,6 +57,9 @@ def deep_sort_keys(value)
 end
 
 def generate_conformance_challenge_id(params)
+  secret_key = params.fetch("secretKey")
+  raise "secretKey must be at least #{MINIMUM_SECRET_KEY_BYTES} bytes" if secret_key.bytesize < MINIMUM_SECRET_KEY_BYTES
+
   request_b64 = base64url_encode(stable_json(params["request"] || {}))
   payload = [
     params["realm"] || "",
@@ -65,7 +70,7 @@ def generate_conformance_challenge_id(params)
     params["digest"] || "",
     params["opaque"] || ""
   ].join("|")
-  digest = OpenSSL::HMAC.digest("SHA256", params.fetch("secretKey").encode("UTF-8"), payload.encode("UTF-8"))
+  digest = OpenSSL::HMAC.digest("SHA256", secret_key.encode("UTF-8"), payload.encode("UTF-8"))
   base64url_encode(digest)
 end
 

--- a/conformance/adapters/ruby/adapter.rb
+++ b/conformance/adapters/ruby/adapter.rb
@@ -290,7 +290,7 @@ def verify_stripe_external_id_binding(input)
   require "mpp/methods/stripe"
   require "mpp/server"
 
-  secret_key = "conformance-stripe-secret"
+  secret_key = "conformance-stripe-secret-key-32"
   realm = "conformance.local"
   expires = "2099-01-29T12:05:30Z"
   challenge = Mpp::Challenge.create(

--- a/conformance/adapters/rust/src/main.rs
+++ b/conformance/adapters/rust/src/main.rs
@@ -524,12 +524,18 @@ struct ChallengeIdParams<'a> {
     opaque: Option<&'a str>,
 }
 
-fn generate_conformance_challenge_id(
-    params: ChallengeIdParams<'_>,
-) -> Result<String, std::fmt::Error> {
+fn generate_conformance_challenge_id(params: ChallengeIdParams<'_>) -> Result<String, String> {
+    const MINIMUM_SECRET_KEY_BYTES: usize = 32;
     type HmacSha256 = Hmac<Sha256>;
 
-    let request_json = stable_json(params.request)?;
+    if params.secret_key.as_bytes().len() < MINIMUM_SECRET_KEY_BYTES {
+        return Err(format!(
+            "secretKey must be at least {} bytes",
+            MINIMUM_SECRET_KEY_BYTES
+        ));
+    }
+
+    let request_json = stable_json(params.request).map_err(|e| e.to_string())?;
     let request_b64 = base64url_encode(request_json.as_bytes());
     let hmac_input = [
         params.realm,

--- a/conformance/golden/adapter.ts
+++ b/conformance/golden/adapter.ts
@@ -30,6 +30,8 @@ import { Challenge, Credential, Method, Receipt, z } from 'mppx'
 import * as Client from 'mppx/client'
 import { Mppx, stripe } from 'mppx/server'
 
+const minimumSecretKeyBytes = 32
+
 interface SuccessResult<T> {
 	success: true
 	result: T
@@ -121,6 +123,9 @@ function generateConformanceChallengeId(params: {
 	digest?: string
 	opaque?: string
 }): string {
+	if (Buffer.byteLength(params.secretKey, 'utf8') < minimumSecretKeyBytes)
+		throw new Error(`secretKey must be at least ${minimumSecretKeyBytes} bytes`)
+
 	const requestJson = stableStringify(params.request ?? {})
 	const requestB64 = base64UrlEncode(requestJson)
 	const payload = [

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -498,7 +498,11 @@ class VectorRunner:
             if is_challenge_id:
                 input_data = json.dumps(scenario["input"])
                 result, elapsed_ms = self.run_adapter_timed(adapter, generate_cmd, input_data, timeout=command_timeout)
-                expected = {"success": True, "result": scenario["expected"]}
+                generate_test = tests.get("generate")
+                if generate_test is not None and generate_test is not True:
+                    expected = generate_test
+                else:
+                    expected = {"success": True, "result": scenario["expected"]}
                 passed, error = self.compare_results(expected, result)
                 if passed:
                     passed, error = self.compare_duration(duration_limit_ms, elapsed_ms)

--- a/conformance/vectors/challenge-id.json
+++ b/conformance/vectors/challenge-id.json
@@ -9,12 +9,9 @@
     {
       "name": "required_fields_only",
       "description": "HMAC with only required fields",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -22,18 +19,14 @@
           "amount": "1000000"
         }
       },
-      "expected": "X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4"
+      "expected": "6QDs0BmhrI_v67iWeCMvGqQJEFQ6ErWKlk7zi5xL6t0"
     },
     {
       "name": "with_expires",
       "description": "HMAC with optional expires field",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "optional-fields"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "optional-fields"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -42,18 +35,14 @@
         },
         "expires": "2025-01-06T12:00:00Z"
       },
-      "expected": "ChPX33RkKSZoSUyZcu8ai4hhkvjZJFkZVnvWs5s0iXI"
+      "expected": "ZcHgfEi5_Qyda9NQwUzamsCgCcWXw6N6EH2NLyaSTlg"
     },
     {
       "name": "with_digest",
       "description": "HMAC with optional digest field",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "optional-fields"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "optional-fields"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -62,18 +51,14 @@
         },
         "digest": "sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE"
       },
-      "expected": "JHB7EFsPVb-xsYCo8LHcOzeX1gfXWVoUSzQsZhKAfKM"
+      "expected": "vwnOtW2kwdujK9_uC_taI2e6Jwq86Jwogvq9m--i8eQ"
     },
     {
       "name": "with_expires_and_digest",
       "description": "HMAC with both optional expires and digest fields",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "optional-fields"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "optional-fields"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -83,18 +68,14 @@
         "expires": "2025-01-06T12:00:00Z",
         "digest": "sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE"
       },
-      "expected": "m39jbWWCIfmfJZSwCfvKFFtBl0Qwf9X4nOmDb21peLA"
+      "expected": "HSUJV7QH1E135PSDPlrZ5cLoozV3bv5T4vfVdS3Xyzk"
     },
     {
       "name": "with_opaque",
       "description": "opaque is part of the HMAC input and changes the challenge ID",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "optional-fields"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "optional-fields"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -103,18 +84,14 @@
         },
         "opaque": "trace-123"
       },
-      "expected": "Eygx23gBLxdo3J9NvD8HVzhbozPso8ICyOQNOXHADd0"
+      "expected": "1XJ-Ti0DACNe3E1zHvwH6OdnKlhUx6xKxDbhJyexng4"
     },
     {
       "name": "opaque_route_scope_binding",
       "description": "Route-scope opaque metadata is part of the HMAC input",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "route-scope"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "route-scope"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -123,18 +100,14 @@
         },
         "opaque": "eyJyb3V0ZSI6Ii9hcGkvcHJlbWl1bSJ9"
       },
-      "expected": "s8WLcvXgjlaM4k4iYQqL3M7ADzb1grLYgRwvpVdpBmM"
+      "expected": "qKB3Cm8efoWftvkRf43R5GxatYiXuZPxhs2kA3CvxGM"
     },
     {
       "name": "description_not_in_hmac",
       "description": "description field is not part of HMAC input, so ID matches required_fields_only even with description present",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "description-excluded"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "description-excluded"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -143,17 +116,14 @@
         },
         "description": "API access payment required"
       },
-      "expected": "X6v1eo7fJ76gAxqY0xN9Jd__4lUyDDYmriryOM-5FO4"
+      "expected": "6QDs0BmhrI_v67iWeCMvGqQJEFQ6ErWKlk7zi5xL6t0"
     },
     {
       "name": "multi_field_request",
       "description": "HMAC with multiple fields in request",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -163,18 +133,14 @@
           "recipient": "0xabcd"
         }
       },
-      "expected": "_H5TOnnlW0zduQ5OhQ3EyLVze_TqxLDPda2CGZPZxOc"
+      "expected": "I8ZLhCXrskUbWuwYSSM0My-wk3mnL9_w8cDlEcs2UFo"
     },
     {
       "name": "nested_method_details",
       "description": "HMAC with nested methodDetails in request",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "nested-object"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "nested-object"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -186,18 +152,14 @@
           }
         }
       },
-      "expected": "TqujwpuDDg_zsWGINAd5XObO2rRe6uYufpqvtDmr6N8"
+      "expected": "W8sYOWDDrcuRcku27vjJoqLX0uAnBmql7qAOuQwdmPo"
     },
     {
       "name": "html_sensitive_request_canonicalization",
       "description": "HMAC input preserves HTML-sensitive JSON string characters without escaping them",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "canonicalization"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "canonicalization"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -208,18 +170,14 @@
           "recipient": "merchant"
         }
       },
-      "expected": "9wuIbToTGnzxJuu715tZMeGH5MS0xVO6FgpFLBXqWCY"
+      "expected": "iU2QdYw_u-prmGZWxm58jeBakeYE-ib_u77f9vcW76E"
     },
     {
       "name": "resource_path_query_binding",
       "description": "Route and query resource discriminator is part of the HMAC input",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "resource-binding"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "resource-binding"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -230,18 +188,14 @@
           "resource": "/charge/query-replay?tier=basic"
         }
       },
-      "expected": "URpwDjsh37QzVXUK0gyE_7jJlZHspUo4tJ5GadzFz_Y"
+      "expected": "ge6Ckot8ZHZB_S-6OOlzuKOnUhndJIUarP-zPCtzleE"
     },
     {
       "name": "external_id_request_binding",
       "description": "Server-issued externalId is part of the HMAC input when present in the request",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "metadata-binding"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "metadata-binding"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -252,18 +206,14 @@
           "recipient": "merchant"
         }
       },
-      "expected": "2wXyB6RZGUPTnpU-KA6xh2_xRn184dKN-YhPk7z5qe0"
+      "expected": "PyzaHuf-58VJxeH7oErmMTlnKZZ5yYzRVueWW0MK1hI"
     },
     {
       "name": "fee_payer_policy_binding",
       "description": "Fee-payer policy details are part of the HMAC input when declared by the server",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "fee-payer"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "fee-payer"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -278,35 +228,27 @@
           "recipient": "merchant"
         }
       },
-      "expected": "l-xhcq1GSJxmjOCnvS56QMWbPj1X_S0ebekGEouJJZg"
+      "expected": "Z-51rg0Ds7Xd9FnWiXT3aOs4vyuScuZkxnk-BNRy8QE"
     },
     {
       "name": "empty_request",
       "description": "HMAC with empty request object",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "empty-request"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "empty-request"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
         "request": {}
       },
-      "expected": "yLN7yChAejW9WNmb54HpJIWpdb1WWXeA3_aCx4dxmkU"
+      "expected": "SMpxo_gPWGquX9vAZ-b_OIPsHO3kfdY2s73946Mnwc0"
     },
     {
       "name": "different_realm",
       "description": "Different realm produces different ID",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "field-variation"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "field-variation"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "payments.other.com",
         "method": "tempo",
         "intent": "charge",
@@ -314,18 +256,14 @@
           "amount": "1000000"
         }
       },
-      "expected": "3F5bOo2a9RUihdwKk4hGRvBvzQmVPBMDvW0YM-8GD00"
+      "expected": "NiwWsOUeZDNPegltJVbOHVKR4hHbZR5tnoQ80DVrqyY"
     },
     {
       "name": "different_method",
       "description": "Different method produces different ID",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "field-variation"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "field-variation"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "stripe",
         "intent": "charge",
@@ -333,18 +271,14 @@
           "amount": "1000000"
         }
       },
-      "expected": "o0ra2sd7HcB4Ph0Vns69gRDUhSj5WNOnUopcDqKPLz4"
+      "expected": "IPY59YD2ZWmf3yXnZxbQgYoYejrVB9Nh_rpSkrOeSG0"
     },
     {
       "name": "different_intent",
       "description": "Different intent produces different ID",
-      "tags": [
-        "happy-path",
-        "cross-sdk-validated",
-        "field-variation"
-      ],
+      "tags": ["happy-path", "cross-sdk-validated", "field-variation"],
       "input": {
-        "secretKey": "test-vector-secret",
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "session",
@@ -352,16 +286,14 @@
           "amount": "1000000"
         }
       },
-      "expected": "aAY7_IEDzsznNYplhOSE8cERQxvjFcT4Lcn-7FHjLVE"
+      "expected": "3bUB3LSxOG-lexqNCMGiV-p_j1UeibqWlA-saIiwo5A"
     },
     {
       "name": "basic_charge",
       "description": "Basic charge with full request fields",
-      "tags": [
-        "happy-path"
-      ],
+      "tags": ["happy-path"],
       "input": {
-        "secretKey": "test-secret-key-12345",
+        "secretKey": "test-secret-key-12345-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -371,17 +303,14 @@
           "recipient": "0x1234567890abcdef1234567890abcdef12345678"
         }
       },
-      "expected": "YVI_8tUw5BUXxTtM1O0KdwPkLNg8ZrNVPbNTylsJwX8"
+      "expected": "Go8tV1muorsPUY3eQxjQ2oBMBDRPuK-jdO_E2sbtti8"
     },
     {
       "name": "with_expires_alt_secret",
       "description": "Challenge with expires using alternate secret",
-      "tags": [
-        "happy-path",
-        "optional-fields"
-      ],
+      "tags": ["happy-path", "optional-fields"],
       "input": {
-        "secretKey": "test-secret-key-12345",
+        "secretKey": "test-secret-key-12345-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -392,17 +321,14 @@
         },
         "expires": "2026-01-29T12:00:00Z"
       },
-      "expected": "GpTpqXciXty8sPCn5pZj2uMx_rgFDI9pwk2Y9-6XWuE"
+      "expected": "DAgfntQtAmV_y2J9YWUh-UKvwRTxXhMCvX0uOFzvfOE"
     },
     {
       "name": "with_digest_alt_secret",
       "description": "Challenge with digest using alternate secret",
-      "tags": [
-        "happy-path",
-        "optional-fields"
-      ],
+      "tags": ["happy-path", "optional-fields"],
       "input": {
-        "secretKey": "my-server-secret",
+        "secretKey": "my-server-secret-minimum-32-byte-secret",
         "realm": "payments.example.org",
         "method": "tempo",
         "intent": "charge",
@@ -413,17 +339,14 @@
         },
         "digest": "sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE="
       },
-      "expected": "qcJUPoapy4bFLznQjQUutwPLyXW7FvALrWA_sMENgAY"
+      "expected": "Wck1EzUjlCJIEPEyaYpuZ_8GxC-0TWZPJYcBTH6fwdU"
     },
     {
       "name": "full_challenge_alt_secret",
       "description": "Full challenge with all optional fields using alternate secret",
-      "tags": [
-        "happy-path",
-        "optional-fields"
-      ],
+      "tags": ["happy-path", "optional-fields"],
       "input": {
-        "secretKey": "test-secret-abc123",
+        "secretKey": "test-secret-abc123-minimum-32-byte-secret",
         "realm": "api.tempo.xyz",
         "method": "tempo",
         "intent": "charge",
@@ -437,17 +360,14 @@
         "expires": "2026-02-01T00:00:00Z",
         "digest": "sha-256=abc123def456"
       },
-      "expected": "Lbvu8LQM8rkXaq05ehcvTgHlSxkRnUugtXsV394M5nA"
+      "expected": "_pLIgk1zfLjIqa1aXziYSyyHZLQZQ1WXCBSa3-DK6_E"
     },
     {
       "name": "different_secret_different_id",
       "description": "Same parameters as basic_charge but different secret produces different ID",
-      "tags": [
-        "happy-path",
-        "secret-variation"
-      ],
+      "tags": ["happy-path", "secret-variation"],
       "input": {
-        "secretKey": "different-secret-key",
+        "secretKey": "different-secret-key-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -457,33 +377,27 @@
           "recipient": "0x1234567890abcdef1234567890abcdef12345678"
         }
       },
-      "expected": "LbZG-raSf2z4hOinx0PVcwPMCstsj-gdEBieqxdlUyg"
+      "expected": "iox5xpRvWhpAMaIlMZIKRJHGOIiCNDJrE28AljJJzyE"
     },
     {
       "name": "empty_request_alt_secret",
       "description": "Empty request with alternate secret",
-      "tags": [
-        "happy-path",
-        "empty-request"
-      ],
+      "tags": ["happy-path", "empty-request"],
       "input": {
-        "secretKey": "test-key",
+        "secretKey": "test-key-minimum-32-byte-secret-key",
         "realm": "test.example.com",
         "method": "tempo",
         "intent": "authorize",
         "request": {}
       },
-      "expected": "MYEC2oq3_B3cHa_My1Lx3NQKn_iUiMfsns6361N0SX0"
+      "expected": "XOelcFKZ14F8K1KtmsQsN-PKrpBg2_pwnLg0HJUOd1g"
     },
     {
       "name": "unicode_in_description",
       "description": "Request with unicode characters in description",
-      "tags": [
-        "happy-path",
-        "unicode"
-      ],
+      "tags": ["happy-path", "unicode"],
       "input": {
-        "secretKey": "unicode-test-key",
+        "secretKey": "unicode-test-key-minimum-32-byte-secret",
         "realm": "api.example.com",
         "method": "tempo",
         "intent": "charge",
@@ -491,20 +405,17 @@
           "amount": "100",
           "currency": "EUR",
           "recipient": "0x1111111111111111111111111111111111111111",
-          "description": "Payment for caf\u00e9 \u2615"
+          "description": "Payment for café ☕"
         }
       },
-      "expected": "1_GKJqATKvVnIUY3f8MFq48bMs18JHz_3CBK8pu52yA"
+      "expected": "-UB9jxfPEvTmFw7qvLmqJhDZ-lJ-noCp15ROxPHC4BE"
     },
     {
       "name": "nested_method_details_alt_secret",
       "description": "Nested methodDetails with alternate secret",
-      "tags": [
-        "happy-path",
-        "nested-object"
-      ],
+      "tags": ["happy-path", "nested-object"],
       "input": {
-        "secretKey": "nested-test-key",
+        "secretKey": "nested-test-key-minimum-32-byte-secret",
         "realm": "api.tempo.xyz",
         "method": "tempo",
         "intent": "charge",
@@ -518,7 +429,27 @@
           }
         }
       },
-      "expected": "WqQuVsD-d0Uij4uzx-W_MdUc4wo6wpIuvHNvPIw6G9M"
+      "expected": "rWfhir6e_bnIQdbh6tHUosPEHnxLIaWRDWs-zNHeYug"
+    },
+    {
+      "name": "error_weak_secret_key",
+      "description": "Rejects HMAC secret keys shorter than 32 bytes",
+      "tags": ["error", "security", "secret-key"],
+      "input": {
+        "secretKey": "short",
+        "realm": "api.example.com",
+        "method": "tempo",
+        "intent": "charge",
+        "request": {
+          "amount": "1000000"
+        }
+      },
+      "tests": {
+        "generate": {
+          "success": false,
+          "error_type": "generation_error"
+        }
+      }
     }
   ]
 }

--- a/conformance/vectors/www-authenticate.json
+++ b/conformance/vectors/www-authenticate.json
@@ -241,6 +241,9 @@
       "description": "Rejects a valid JSON request auth-param whose encoded size exceeds the 16 KiB parser cap",
       "tags": ["error", "performance", "size-limit"],
       "maxDurationMs": 1000,
+      "maxDurationMsByAdapter": {
+        "typescript": 3000
+      },
       "wire": {
         "prefix": "Payment id=\"ch_oversized\", realm=\"api.example.com\", method=\"tempo\", intent=\"charge\", request=\"eyJwYWRkaW5nIjoi",
         "repeat": "YWFh",

--- a/conformance/vectors/www-authenticate.json
+++ b/conformance/vectors/www-authenticate.json
@@ -237,6 +237,24 @@
       }
     },
     {
+      "name": "error_oversized_request_parameter",
+      "description": "Rejects a valid JSON request auth-param whose encoded size exceeds the 16 KiB parser cap",
+      "tags": ["error", "performance", "size-limit"],
+      "maxDurationMs": 1000,
+      "wire": {
+        "prefix": "Payment id=\"ch_oversized\", realm=\"api.example.com\", method=\"tempo\", intent=\"charge\", request=\"eyJwYWRkaW5nIjoi",
+        "repeat": "YWFh",
+        "count": 4092,
+        "suffix": "In0\""
+      },
+      "tests": {
+        "parse": {
+          "success": false,
+          "error_type": "parse_error"
+        }
+      }
+    },
+    {
       "name": "error_missing_payment_prefix",
       "description": "Rejects header without Payment prefix",
       "tags": ["error", "invalid-prefix"],


### PR DESCRIPTION
## Summary

- Added a weak secret-key conformance vector for challenge ID generation.
- Added an oversized `WWW-Authenticate` `request` parsing vector.
- Updated bundled adapters and flow fixtures for the 32-byte server secret-key requirement.

## Motivation

The conformance suite should catch SDKs that accept weak HMAC challenge secrets or parse oversized payment challenge request parameters without an early bound.

## Key design considerations

- Keeps successful challenge ID vectors on 32-byte-or-stronger fixture secrets.
- Extends the vector runner to support expected generation failures without adding a new adapter operation.
- Updates the flow harness secret so future conformant SDKs can run the end-to-end flow suite.
