### PR TITLE
fix(conformance): preserve Python Tempo deps and surface verifier crashes

### DIFF
--- a/conformance/adapters/python/adapter.py
+++ b/conformance/adapters/python/adapter.py
@@ -365,8 +365,6 @@ def main():
             error_type = "encoding_error"
         elif command.startswith("generate-"):
             error_type = "generation_error"
-        elif command.startswith("verify-tempo-receipt"):
-            error_type = "verification_error"
         else:
             error_type = "unknown_error"
         print(json.dumps(error(str(e), error_type)))

--- a/conformance/scripts/use_local_sdk.py
+++ b/conformance/scripts/use_local_sdk.py
@@ -64,8 +64,8 @@ def configure_python(conformance_dir: Path, sdk_path: Path) -> None:
     pyproject = conformance_dir / "adapters" / "python" / "pyproject.toml"
     replace_one(
         pyproject,
-        r'^(\s*)"pympp[^"]*",\s*$',
-        rf'\1"pympp @ {sdk_path.as_uri()}",',
+        r'^(\s*)"pympp(\[[^\]]*\])?[^"]*",\s*$',
+        rf'\1"pympp\2 @ {sdk_path.as_uri()}",',
         "Python pympp dependency",
     )
 


### PR DESCRIPTION
- `use_local_sdk.py` now keeps the `[tempo]` extra when pointing the Python adapter at a local SDK, so the keccak backend installs and Tempo vectors pass (113/113).
- `verify-tempo-receipt` crashes now report `unknown_error` instead of `verification_error`, so infra failures fail vectors loudly instead of masquerading as rejections.