### PR TITLE
test: reject empty challenge ids during formatting

### DIFF
--- a/conformance/HARNESS_SPEC.md
+++ b/conformance/HARNESS_SPEC.md
@@ -10,6 +10,7 @@ calls.
 The normative contract lives in JSON Schema:
 
 - [`schemas/adapter-manifest.schema.json`](./schemas/adapter-manifest.schema.json)
+- [`schemas/adapter-request-envelope.schema.json`](./schemas/adapter-request-envelope.schema.json)
 - [`schemas/adapter-request.schema.json`](./schemas/adapter-request.schema.json)
 - [`schemas/adapter-response.schema.json`](./schemas/adapter-response.schema.json)
 - [`schemas/operation-registry.schema.json`](./schemas/operation-registry.schema.json)
@@ -98,9 +99,11 @@ Rules:
 
 ## Adapter ABI
 
-All adapter requests must validate against
-`schemas/adapter-request.schema.json`. All adapter responses must validate
-against `schemas/adapter-response.schema.json`.
+Adapter requests normally validate against `schemas/adapter-request.schema.json`.
+Negative vectors whose expected result is an error validate only against
+`schemas/adapter-request-envelope.schema.json`, allowing deliberately invalid
+operation inputs to reach the SDK under test. All adapter responses must
+validate against `schemas/adapter-response.schema.json`.
 
 Request:
 

--- a/conformance/adapters/go/main.go
+++ b/conformance/adapters/go/main.go
@@ -155,6 +155,10 @@ func handleFormatWWWAuthenticate(input string) {
 		printJSON(commandResponse{Success: false, Error: err.Error(), ErrorType: "format_error"})
 		return
 	}
+	if challenge.ID == "" {
+		printJSON(commandResponse{Success: false, Error: "id must not be empty", ErrorType: "format_error"})
+		return
+	}
 
 	header, err := challenge.ToAuthenticateStrict(challenge.Realm)
 	if err != nil {

--- a/conformance/adapters/python/adapter.py
+++ b/conformance/adapters/python/adapter.py
@@ -316,6 +316,8 @@ def main():
             print(json.dumps(success(receipt_to_dict(receipt))))
         elif command == "format-www-authenticate":
             data = json.loads(input_data)
+            if not data.get("id"):
+                raise ValueError("id must not be empty")
             challenge = Challenge(
                 id=data["id"],
                 method=data["method"],

--- a/conformance/adapters/ruby/adapter.rb
+++ b/conformance/adapters/ruby/adapter.rb
@@ -375,6 +375,7 @@ def run_command(command, input)
     success(receipt_to_h(Mpp::Receipt.from_payment_receipt(input)))
   when "format-www-authenticate"
     data = JSON.parse(input)
+    raise ArgumentError, "id must not be empty" if data.fetch("id", "").empty?
     success(challenge_from_h(data).to_www_authenticate(data.fetch("realm", "")))
   when "format-authorization"
     data = JSON.parse(input)

--- a/conformance/adapters/rust/src/main.rs
+++ b/conformance/adapters/rust/src/main.rs
@@ -201,6 +201,11 @@ fn handle_parse_receipt(input: &str) {
 fn handle_format_www_authenticate(input: &str) {
     match serde_json::from_str::<Value>(input) {
         Ok(value) => {
+            let id = str_field(&value, "id");
+            if id.is_empty() {
+                print_error("id must not be empty", "format_error");
+                return;
+            }
             let request_obj = value.get("request").cloned().unwrap_or(json!({}));
             let request_b64 = match Base64UrlJson::from_value(&request_obj) {
                 Ok(b64) => b64,
@@ -211,7 +216,7 @@ fn handle_format_www_authenticate(input: &str) {
             };
 
             let challenge = PaymentChallenge {
-                id: str_field(&value, "id"),
+                id,
                 realm: str_field(&value, "realm"),
                 method: str_field(&value, "method").into(),
                 intent: str_field(&value, "intent").into(),

--- a/conformance/schemas/adapter-request-envelope.schema.json
+++ b/conformance/schemas/adapter-request-envelope.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://tempo.xyz/mpp-tools/conformance/schemas/adapter-request-envelope.schema.json",
+  "title": "MPP Conformance Adapter Request Envelope",
+  "type": "object",
+  "required": ["schema", "op", "input"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": { "const": 1 },
+    "op": { "$ref": "protocol.schema.json#/$defs/Operation" },
+    "input": true,
+    "context": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "caseName": { "type": "string" },
+        "vectorName": { "type": "string" },
+        "timeoutMs": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}

--- a/conformance/schemas/adapter-request.schema.json
+++ b/conformance/schemas/adapter-request.schema.json
@@ -2,24 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://tempo.xyz/mpp-tools/conformance/schemas/adapter-request.schema.json",
   "title": "MPP Conformance Adapter Request",
-  "type": "object",
-  "required": ["schema", "op", "input"],
-  "additionalProperties": false,
-  "properties": {
-    "schema": { "const": 1 },
-    "op": { "$ref": "protocol.schema.json#/$defs/Operation" },
-    "input": true,
-    "context": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "caseName": { "type": "string" },
-        "vectorName": { "type": "string" },
-        "timeoutMs": { "type": "integer", "minimum": 1 }
-      }
-    }
-  },
   "allOf": [
+    { "$ref": "adapter-request-envelope.schema.json" },
     {
       "if": { "properties": { "op": { "const": "challenge.parse" } }, "required": ["op"] },
       "then": { "properties": { "input": { "$ref": "protocol.schema.json#/$defs/HeaderInput" } } }

--- a/conformance/scripts/harness.py
+++ b/conformance/scripts/harness.py
@@ -269,7 +269,14 @@ class AdapterClient:
     def __init__(self, adapter: AdapterConfig):
         self.adapter = adapter
 
-    def call(self, op: str, input_value: Any, context: dict[str, Any] | None = None, timeout: float = 30) -> dict[str, Any]:
+    def call(
+        self,
+        op: str,
+        input_value: Any,
+        context: dict[str, Any] | None = None,
+        timeout: float = 30,
+        validate_input: bool = True,
+    ) -> dict[str, Any]:
         if op not in self.adapter.capabilities:
             return {
                 "ok": False,
@@ -282,7 +289,12 @@ class AdapterClient:
         request: dict[str, Any] = {"schema": 1, "op": op, "input": input_value}
         if context:
             request["context"] = context
-        validate_value(request, "adapter-request.schema.json", f"{self.adapter.name} request")
+        request_schema = (
+            "adapter-request.schema.json"
+            if validate_input
+            else "adapter-request-envelope.schema.json"
+        )
+        validate_value(request, request_schema, f"{self.adapter.name} request")
 
         env = os.environ.copy()
         if self.adapter.env:
@@ -333,7 +345,18 @@ class AdapterClient:
             }
         return response
 
-    def run_legacy_command(self, command: str, input_data: str, timeout: float = 30) -> dict[str, Any]:
+    def run_legacy_command(
+        self,
+        command: str,
+        input_data: str,
+        timeout: float = 30,
+        validate_input: bool = True,
+    ) -> dict[str, Any]:
         op, input_value = request_input_for_command(command, input_data)
-        response = self.call(op, input_value, timeout=timeout)
+        response = self.call(
+            op,
+            input_value,
+            timeout=timeout,
+            validate_input=validate_input,
+        )
         return legacy_response_for_operation(op, response)

--- a/conformance/scripts/test_harness.py
+++ b/conformance/scripts/test_harness.py
@@ -4,10 +4,13 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from jsonschema import Draft202012Validator
 
 from harness import (
+    AdapterClient,
+    AdapterConfig,
     FLOW_CASES_PATH,
     FLOW_RESULTS_PATH,
     SCHEMA_STORE,
@@ -20,6 +23,62 @@ from harness import (
     validate_vector_scenarios,
     write_flow_results,
 )
+
+
+class AdapterClientValidationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.adapter = AdapterConfig(
+            name="test",
+            command=["test-adapter"],
+            capabilities=["challenge.format"],
+        )
+        self.client = AdapterClient(self.adapter)
+        self.invalid_challenge = {
+            "id": "",
+            "realm": "api.example.com",
+            "method": "tempo",
+            "intent": "charge",
+            "request": {},
+        }
+
+    @patch("harness.subprocess.run")
+    def test_validates_operation_input_by_default(self, run) -> None:
+        with self.assertRaisesRegex(ValueError, "failed schema validation"):
+            self.client.call("challenge.format", self.invalid_challenge)
+
+        run.assert_not_called()
+
+    @patch("harness.subprocess.run")
+    def test_expected_failure_can_reach_adapter(self, run) -> None:
+        run.return_value.returncode = 0
+        run.return_value.stdout = json.dumps(
+            {
+                "ok": False,
+                "error": {"type": "format_error", "message": "id is required"},
+            }
+        )
+
+        result = self.client.call(
+            "challenge.format",
+            self.invalid_challenge,
+            validate_input=False,
+        )
+
+        self.assertEqual(result["error"]["type"], "format_error")
+        request = json.loads(run.call_args.kwargs["input"])
+        self.assertEqual(request["input"]["id"], "")
+
+    @patch("harness.subprocess.run")
+    def test_expected_failure_still_validates_request_envelope(self, run) -> None:
+        with self.assertRaisesRegex(ValueError, "Additional properties are not allowed"):
+            self.client.call(
+                "challenge.format",
+                self.invalid_challenge,
+                context={"unexpected": True},
+                validate_input=False,
+            )
+
+        run.assert_not_called()
 
 
 class RepositoryDataSchemaTests(unittest.TestCase):

--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -11,7 +11,7 @@ import unittest
 from pathlib import Path
 
 from harness import AdapterConfig
-from vector_runner import VectorRunner
+from vector_runner import VectorRunner, expects_failure
 
 
 class VectorRunnerHelperTest(unittest.TestCase):
@@ -36,6 +36,21 @@ class VectorRunnerHelperTest(unittest.TestCase):
         }
 
         self.assertEqual(self.runner.duration_limit_ms(scenario, self.adapter), 5000)
+
+    def test_expected_failure_detection(self) -> None:
+        cases = [
+            ({"success": False}, "success", True),
+            ({"success": True}, "success", False),
+            ({"ok": False}, "ok", True),
+            (True, "success", False),
+        ]
+
+        for expectation, result_key, expected in cases:
+            with self.subTest(expectation=expectation, result_key=result_key):
+                self.assertEqual(
+                    expects_failure(expectation, result_key),
+                    expected,
+                )
 
     def test_command_timeout_leaves_room_for_reporting_duration_failure(self) -> None:
         self.assertEqual(self.runner.command_timeout_seconds(None), 30.0)

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -62,6 +62,11 @@ def base64url_decode(s: str) -> bytes:
     return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
 
+def expects_failure(expectation: Any, result_key: str = "success") -> bool:
+    """Return whether a vector explicitly expects an adapter error."""
+    return isinstance(expectation, dict) and expectation.get(result_key) is False
+
+
 def compute_diff(expected: Any, actual: Any) -> str:
     """Compute a human-readable diff between expected and actual values."""
     diff = DeepDiff(expected, actual, ignore_order=True, verbose_level=2)
@@ -193,19 +198,40 @@ class VectorRunner:
         return {"success": False, "error": message, "error_type": "unknown_error"}
 
     def run_adapter(
-        self, adapter: AdapterConfig, command: str, input_data: str, timeout: float = 30
+        self,
+        adapter: AdapterConfig,
+        command: str,
+        input_data: str,
+        timeout: float = 30,
+        validate_input: bool = True,
     ) -> dict[str, Any]:
         """Run an adapter operation through the schema-backed JSON ABI."""
         try:
-            return AdapterClient(adapter).run_legacy_command(command, input_data, timeout=timeout)
+            return AdapterClient(adapter).run_legacy_command(
+                command,
+                input_data,
+                timeout=timeout,
+                validate_input=validate_input,
+            )
         except Exception as exc:
             return self._error_result(str(exc))
 
     def run_adapter_timed(
-        self, adapter: AdapterConfig, command: str, input_data: str, timeout: float = 30
+        self,
+        adapter: AdapterConfig,
+        command: str,
+        input_data: str,
+        timeout: float = 30,
+        validate_input: bool = True,
     ) -> tuple[dict[str, Any], float]:
         start = time.perf_counter()
-        result = self.run_adapter(adapter, command, input_data, timeout=timeout)
+        result = self.run_adapter(
+            adapter,
+            command,
+            input_data,
+            timeout=timeout,
+            validate_input=validate_input,
+        )
         elapsed_ms = (time.perf_counter() - start) * 1000
         return result, elapsed_ms
 
@@ -216,10 +242,17 @@ class VectorRunner:
         input_value: Any,
         context: dict[str, Any] | None = None,
         timeout: float = 30,
+        validate_input: bool = True,
     ) -> tuple[dict[str, Any], float]:
         start = time.perf_counter()
         try:
-            result = AdapterClient(adapter).call(operation, input_value, context=context, timeout=timeout)
+            result = AdapterClient(adapter).call(
+                operation,
+                input_value,
+                context=context,
+                timeout=timeout,
+                validate_input=validate_input,
+            )
         except Exception as exc:
             result = {"ok": False, "error": {"type": "unknown_error", "message": str(exc)}}
         elapsed_ms = (time.perf_counter() - start) * 1000
@@ -538,14 +571,15 @@ class VectorRunner:
             command_timeout = self.command_timeout_seconds(duration_limit_ms)
 
             if operation:
+                expected = scenario["expected"]
                 result, elapsed_ms = self.run_operation_timed(
                     adapter,
                     operation,
                     scenario["input"],
                     context={"caseName": name, "vectorName": vector_name},
                     timeout=command_timeout,
+                    validate_input=not expects_failure(expected, "ok"),
                 )
-                expected = scenario["expected"]
                 passed, error = self.compare_adapter_response(expected, result)
                 if passed:
                     passed, error = self.compare_duration(duration_limit_ms, elapsed_ms)
@@ -563,12 +597,18 @@ class VectorRunner:
 
             if is_challenge_id:
                 input_data = json.dumps(scenario["input"])
-                result, elapsed_ms = self.run_adapter_timed(adapter, generate_cmd, input_data, timeout=command_timeout)
                 generate_test = tests.get("generate")
                 if generate_test is not None and generate_test is not True:
                     expected = generate_test
                 else:
                     expected = {"success": True, "result": scenario["expected"]}
+                result, elapsed_ms = self.run_adapter_timed(
+                    adapter,
+                    generate_cmd,
+                    input_data,
+                    timeout=command_timeout,
+                    validate_input=not expects_failure(expected),
+                )
                 passed, error = self.compare_results(expected, result)
                 if passed:
                     passed, error = self.compare_duration(duration_limit_ms, elapsed_ms)
@@ -597,12 +637,20 @@ class VectorRunner:
             # Parse test
             parse_test = tests.get("parse")
             if parse_test is not None and parse_cmd and wire is not None:
-                result, elapsed_ms = self.run_adapter_timed(adapter, parse_cmd, wire, timeout=command_timeout)
                 if parse_test is True:
                     expected = {"success": True, "result": obj}
-                    passed, error = self.compare_parse_results_semantic(expected, result, parse_cmd)
                 else:
                     expected = parse_test
+                result, elapsed_ms = self.run_adapter_timed(
+                    adapter,
+                    parse_cmd,
+                    wire,
+                    timeout=command_timeout,
+                    validate_input=not expects_failure(expected),
+                )
+                if parse_test is True:
+                    passed, error = self.compare_parse_results_semantic(expected, result, parse_cmd)
+                else:
                     passed, error = self.compare_results(parse_test, result)
                 if passed:
                     passed, error = self.compare_duration(duration_limit_ms, elapsed_ms)
@@ -627,12 +675,20 @@ class VectorRunner:
                     format_input = obj
                 else:
                     format_input = json.dumps(obj)
-                result, elapsed_ms = self.run_adapter_timed(adapter, format_cmd, format_input, timeout=command_timeout)
                 if format_test is True:
                     expected_format = {"success": True, "result": wire}
-                    passed, error = self.compare_format_results_semantic(adapter, expected_format, result, format_cmd, parse_cmd)
                 else:
                     expected_format = format_test
+                result, elapsed_ms = self.run_adapter_timed(
+                    adapter,
+                    format_cmd,
+                    format_input,
+                    timeout=command_timeout,
+                    validate_input=not expects_failure(expected_format),
+                )
+                if format_test is True:
+                    passed, error = self.compare_format_results_semantic(adapter, expected_format, result, format_cmd, parse_cmd)
+                else:
                     passed, error = self.compare_results(expected_format, result)
                 if passed:
                     passed, error = self.compare_duration(duration_limit_ms, elapsed_ms)

--- a/conformance/vectors/www-authenticate.json
+++ b/conformance/vectors/www-authenticate.json
@@ -180,6 +180,24 @@
       }
     },
     {
+      "name": "error_empty_id_format",
+      "description": "Rejects challenge object with empty id during formatting",
+      "tags": ["error", "invalid-value"],
+      "object": {
+        "id": "",
+        "intent": "charge",
+        "method": "tempo",
+        "realm": "api.example.com",
+        "request": {}
+      },
+      "tests": {
+        "format": {
+          "success": false,
+          "error_type": "format_error"
+        }
+      }
+    },
+    {
       "name": "payment_keyword_in_quoted_realm",
       "description": "The word 'Payment' inside a quoted parameter value must not be mistaken for a second auth scheme",
       "tags": ["happy-path", "edge-case", "quoted-string", "scheme-boundary"],


### PR DESCRIPTION
## Summary
- Adds a `www-authenticate` conformance vector for rejecting a challenge object with `id: ""` during formatting/construction.
- Complements the existing parse vector `error_empty_id`, so parse and format expectations now agree.

This follows https://github.com/tempoxyz/mpp-tools/issues/19#issuecomment-4752175102.

## Verification
- `python3 -m json.tool conformance/vectors/www-authenticate.json`
- `git diff --check`
- `python3 scripts/vector_runner.py --adapter typescript --vector www-authenticate --verbose` currently reports 37 passed, 1 failed: the new `error_empty_id_format` case fails against pinned `mppx@0.7.0`, as expected until the mppx fix is released/consumed.