### PR TITLE
fix(conformance): tidy Go adapter deps for local SDK

### DIFF
--- a/conformance/scripts/use_local_sdk.py
+++ b/conformance/scripts/use_local_sdk.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -72,6 +73,8 @@ def configure_python(conformance_dir: Path, sdk_path: Path) -> None:
 
 def configure_go(conformance_dir: Path, sdk_path: Path) -> None:
     adapter_dir = conformance_dir / "adapters" / "go"
+    go_env = os.environ.copy()
+    go_env.setdefault("GOTOOLCHAIN", "auto")
     result = subprocess.run(
         [
             "go",
@@ -81,12 +84,24 @@ def configure_go(conformance_dir: Path, sdk_path: Path) -> None:
             f"github.com/tempoxyz/mpp-go={sdk_path}",
         ],
         cwd=adapter_dir,
+        env=go_env,
         capture_output=True,
         text=True,
     )
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip()
         raise RuntimeError(f"go mod edit failed: {detail}")
+
+    result = subprocess.run(
+        ["go", "mod", "tidy"],
+        cwd=adapter_dir,
+        env=go_env,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"go mod tidy failed: {detail}")
 
 
 def configure_typescript(conformance_dir: Path, sdk_path: Path) -> None:


### PR DESCRIPTION
Fixes the Go SDK conformance adapter setup for SDK PRs that change transitive dependencies.

The reusable SDK conformance workflow edits the Go adapter to replace `github.com/tempoxyz/mpp-go` with the PR checkout. After that replace, the adapter module still needs to refresh its module graph; otherwise Go builds fail with missing `go.sum` entries for dependencies from the local SDK checkout.

Validation:
- `python3 -m py_compile conformance/scripts/use_local_sdk.py`
- Simulated the CI path against `figtracer/mpp-go:codex/body-digest-server-conformance`: `use_local_sdk.py --adapter go`, `go mod download`, and `go build -o adapter .`

Observed affected `mpp-go` PRs:
- tempoxyz/mpp-go#55: missing `github.com/redis/go-redis/v9` sum
- tempoxyz/mpp-go#54: missing `github.com/redis/go-redis/v9` sum
- tempoxyz/mpp-go#58/#62: same Redis sum failure
- tempoxyz/mpp-go#63: same adapter-module failure class, with newer SDK dependency sums