### PR TITLE
fix(policy): directory-style path patterns never match in conformance gating

### DIFF
--- a/conformance/scripts/check_conformance_policy.py
+++ b/conformance/scripts/check_conformance_policy.py
@@ -41,14 +41,15 @@ def split_patterns(value: str) -> list[str]:
 
 def path_matches(path: str, pattern: str) -> bool:
     normalized = path.strip("/")
+    is_dir_pattern = pattern.endswith("/")
     normalized_pattern = pattern.strip("/")
     if not normalized_pattern:
         return False
     if normalized_pattern.endswith("/**"):
         prefix = normalized_pattern[:-3].rstrip("/")
         return normalized == prefix or normalized.startswith(prefix + "/")
-    if normalized_pattern.endswith("/"):
-        return normalized.startswith(normalized_pattern)
+    if is_dir_pattern:
+        return normalized.startswith(normalized_pattern + "/")
     return fnmatchcase(normalized, normalized_pattern)
 
 

--- a/conformance/scripts/select_ci_adapters.py
+++ b/conformance/scripts/select_ci_adapters.py
@@ -52,12 +52,15 @@ FULL_PATTERNS = [
 
 def path_matches(path: str, pattern: str) -> bool:
     normalized = path.strip("/")
+    is_dir_pattern = pattern.endswith("/")
     normalized_pattern = pattern.strip("/")
+    if not normalized_pattern:
+        return False
     if normalized_pattern.endswith("/**"):
         prefix = normalized_pattern[:-3].rstrip("/")
         return normalized == prefix or normalized.startswith(prefix + "/")
-    if normalized_pattern.endswith("/"):
-        return normalized.startswith(normalized_pattern)
+    if is_dir_pattern:
+        return normalized.startswith(normalized_pattern + "/")
     return fnmatchcase(normalized, normalized_pattern)
 
 

--- a/conformance/scripts/test_check_conformance_policy.py
+++ b/conformance/scripts/test_check_conformance_policy.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import os
 import subprocess
@@ -13,6 +14,54 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).with_name("check_conformance_policy.py")
+
+# Modules that each carry a copy of path_matches and must stay in sync.
+PATH_MATCH_MODULES = [
+    "check_conformance_policy",
+    "validate_conformance_pr",
+    "select_ci_adapters",
+]
+
+
+class PathMatchesTest(unittest.TestCase):
+    def each_path_matches(self):
+        sys.path.insert(0, str(SCRIPT.parent))
+        try:
+            for module_name in PATH_MATCH_MODULES:
+                module = importlib.import_module(module_name)
+                yield module_name, module.path_matches
+        finally:
+            sys.path.remove(str(SCRIPT.parent))
+
+    def test_directory_pattern_matches_files_under_directory(self) -> None:
+        for module_name, path_matches in self.each_path_matches():
+            with self.subTest(module=module_name):
+                self.assertTrue(path_matches("src/proto/wire.go", "src/proto/"))
+                self.assertTrue(path_matches("src/proto/nested/deep.rs", "src/proto/"))
+                self.assertTrue(path_matches("/src/proto/wire.go", "src/proto/"))
+
+    def test_directory_pattern_does_not_overmatch(self) -> None:
+        for module_name, path_matches in self.each_path_matches():
+            with self.subTest(module=module_name):
+                self.assertFalse(path_matches("src/protocol/wire.go", "src/proto/"))
+                self.assertFalse(path_matches("src/proto", "src/proto/"))
+                self.assertFalse(path_matches("other/src/proto/wire.go", "src/proto/"))
+
+    def test_recursive_glob_pattern_still_matches(self) -> None:
+        for module_name, path_matches in self.each_path_matches():
+            with self.subTest(module=module_name):
+                self.assertTrue(path_matches("conformance/vectors/receipt.json", "conformance/vectors/**"))
+                self.assertTrue(path_matches("conformance/vectors", "conformance/vectors/**"))
+                self.assertFalse(path_matches("conformance/schemas/x.json", "conformance/vectors/**"))
+
+    def test_exact_and_glob_patterns_still_match(self) -> None:
+        for module_name, path_matches in self.each_path_matches():
+            with self.subTest(module=module_name):
+                self.assertTrue(path_matches("conformance/operations.json", "conformance/operations.json"))
+                self.assertTrue(path_matches("pkg/parse.go", "pkg/*.go"))
+                self.assertFalse(path_matches("pkg/readme.md", "pkg/*.go"))
+                self.assertFalse(path_matches("pkg/parse.go", ""))
+                self.assertFalse(path_matches("pkg/parse.go", "/"))
 
 
 class CheckConformancePolicyTest(unittest.TestCase):

--- a/conformance/scripts/validate_conformance_pr.py
+++ b/conformance/scripts/validate_conformance_pr.py
@@ -19,12 +19,15 @@ def split_patterns(value: str) -> list[str]:
 
 def path_matches(path: str, pattern: str) -> bool:
     normalized = path.strip("/")
+    is_dir_pattern = pattern.endswith("/")
     normalized_pattern = pattern.strip("/")
+    if not normalized_pattern:
+        return False
     if normalized_pattern.endswith("/**"):
         prefix = normalized_pattern[:-3].rstrip("/")
         return normalized == prefix or normalized.startswith(prefix + "/")
-    if normalized_pattern.endswith("/"):
-        return normalized.startswith(normalized_pattern)
+    if is_dir_pattern:
+        return normalized.startswith(normalized_pattern + "/")
     return fnmatchcase(normalized, normalized_pattern)
 
 


### PR DESCRIPTION
# fix(policy): directory-style path patterns never match in conformance gating

## Problem

`path_matches()` — duplicated across three CI policy scripts — has an unreachable
branch. The pattern is normalized with `pattern.strip("/")`, which removes the
trailing slash, so the directory-prefix check below it can never fire:

```python
normalized_pattern = pattern.strip("/")   # "src/proto/" -> "src/proto"
...
if normalized_pattern.endswith("/"):      # never true after strip("/")
    return normalized.startswith(normalized_pattern)
```

A directory-style pattern such as `proto/` (a natural GitHub-path-filter style
for the `protocol-paths` / `conformance-paths` inputs) falls through to
`fnmatchcase(path, "proto")`, which only matches a file literally named
`proto`. Reproduced:

```python
>>> path_matches("src/proto/wire.go", "src/proto/")
False
```

The failure direction is the dangerous one: an SDK repo that configures
`protocol-paths: proto/` gets `protocol_changed=false` for every PR touching
`proto/`, so protocol-sensitive changes silently bypass the conformance gate.
The same dead branch makes `select_ci_adapters.py` drop those files from
adapter selection and can make `validate_conformance_pr.py` reject valid
coverage PRs.

## Fix

Record whether the pattern is directory-style *before* stripping slashes, and
match on the directory prefix explicitly:

```python
is_dir_pattern = pattern.endswith("/")
normalized_pattern = pattern.strip("/")
...
if is_dir_pattern:
    return normalized.startswith(normalized_pattern + "/")
```

`dir/` now matches every file under `dir/` (recursively), does not match a
file literally named `dir`, and does not over-match sibling directories that
share the prefix (`src/proto/` no longer risks matching `src/protocol/…`).
The `/**` and plain-glob branches are unchanged. All three copies were fixed
identically, and the `if not normalized_pattern` empty-pattern guard that only
`check_conformance_policy.py` had is now present in all three.

## Testing

- Added `PathMatchesTest` to `test_check_conformance_policy.py`, which
  exercises all three module copies (directory patterns, `**` globs, exact
  paths, empty patterns) so the copies cannot silently drift again.
- `python3 scripts/test_check_conformance_policy.py` — 7 tests pass
  (3 pre-existing subprocess tests + 4 new).