### PR TITLE
fix(flows): survive malformed requests in the compliance server

### DIFF
--- a/conformance/flows/compliance-server.ts
+++ b/conformance/flows/compliance-server.ts
@@ -140,11 +140,25 @@ const mpp = Server.Mppx.create({
 })
 
 function readBody(req: http.IncomingMessage): Promise<string> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const chunks: Buffer[] = []
     req.on('data', (chunk: Buffer) => chunks.push(chunk))
     req.on('end', () => resolve(Buffer.concat(chunks).toString()))
+    // Without this an aborted upload leaves the promise pending forever and
+    // the unheard 'error' event tears down the whole server process.
+    req.on('error', reject)
   })
+}
+
+function deserializeCredentialSafely(
+  header: string | undefined,
+): ReturnType<typeof Credential.deserialize> | undefined {
+  if (!header) return undefined
+  try {
+    return Credential.deserialize(header)
+  } catch {
+    return undefined
+  }
 }
 
 function sendProblemDetails(
@@ -244,7 +258,7 @@ function sendJsonRpc(res: http.ServerResponse, body: unknown): void {
   res.end(JSON.stringify(body))
 }
 
-const handler: http.RequestListener = async (req, res) => {
+const handleRequest = async (req: http.IncomingMessage, res: http.ServerResponse): Promise<void> => {
   const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`)
   const flowCase = caseByPath.get(url.pathname)
 
@@ -459,9 +473,7 @@ const handler: http.RequestListener = async (req, res) => {
   }
 
   if (flowCase.digest_binding) {
-    const credential = req.headers.authorization
-      ? Credential.deserialize(req.headers.authorization)
-      : undefined
+    const credential = deserializeCredentialSafely(req.headers.authorization)
     if (credential?.challenge.digest !== paymentDigest(requestBody ?? '')) {
       sendChallenge(res, flowChallenge(flowCase))
       return
@@ -469,9 +481,7 @@ const handler: http.RequestListener = async (req, res) => {
   }
 
   if (flowCase.bind_request_resource) {
-    const credential = req.headers.authorization
-      ? Credential.deserialize(req.headers.authorization)
-      : undefined
+    const credential = deserializeCredentialSafely(req.headers.authorization)
     const challengeRequest = credential?.challenge.request as Record<string, unknown> | undefined
     if (challengeRequest?.resource !== `${url.pathname}${url.search}`) {
       sendChallenge(res, flowChallenge(flowCase, undefined, flowRequest))
@@ -529,6 +539,26 @@ const handler: http.RequestListener = async (req, res) => {
   res.statusCode = response.status
   response.headers.forEach((value, key) => res.setHeader(key, value))
   res.end(await response.text())
+}
+
+// Error boundary: a malformed request (bad JSON-RPC body, garbage
+// Authorization header, invalid Host) must produce a 400 for that request,
+// not an unhandled rejection that kills the server for every remaining
+// flow case and adapter.
+const handler: http.RequestListener = async (req, res) => {
+  try {
+    await handleRequest(req, res)
+  } catch (err) {
+    console.error(`request failed: ${req.method} ${req.url}:`, err)
+    if (!res.headersSent) {
+      res.statusCode = 400
+      res.setHeader('Content-Type', 'application/json')
+      res.setHeader('Cache-Control', 'no-store')
+    }
+    if (!res.writableEnded) {
+      res.end(JSON.stringify({ ok: false, error: 'malformed request' }))
+    }
+  }
 }
 
 const server = http.createServer(handler)


### PR DESCRIPTION
# compliance-server: one malformed request can kill the whole flow run

## Repro

Against the server as it ships today:

```console
$ curl -X POST -d 'not json' http://127.0.0.1:43999/rpc
curl: (52) Empty reply from server

$ curl http://127.0.0.1:43999/free      # server is gone
curl: (7) Failed to connect
```

`JSON.parse` throws inside the async request listener, nothing catches it, and
Node's default `unhandled-rejections=throw` terminates the process. Because the
flow runner starts this server **once** and reuses it for every adapter, the
crash cascades: every remaining flow case for every remaining adapter fails
with connection errors, and the eventual report points nowhere near the actual
cause.

The listener had several such landmines, all reachable with a single request:

| Input | Throwing call |
|---|---|
| invalid JSON body on `/rpc` | `JSON.parse(raw)` |
| JSON-RPC credential without `challenge` | `credential.challenge.id` |
| garbage `Authorization` on a `digest_binding` route | `Credential.deserialize(...)` |
| garbage `Authorization` on a `bind_request_resource` route | `Credential.deserialize(...)` |
| malformed `Host` header | `new URL(...)` |
| client aborting a POST mid-body | unheard `'error'` event on `req` (plus a forever-pending `readBody` promise) |

Notably the `invalid_challenge_id` branch *does* guard its
`Challenge.deserialize` with try/catch — the unguarded copies elsewhere look
like oversights rather than intent.

## Fix

Three layers, smallest change that makes each input class behave sensibly:

1. **Error boundary.** The listener body moved to `handleRequest()`; the
   exported listener wraps it in try/catch and answers `400` with
   `{"ok": false, "error": "malformed request"}` (only if headers weren't
   already sent), logging the error to stderr. The process no longer dies.
2. **`readBody`** now rejects on `req.on('error')`, so an aborted upload
   surfaces as a caught error instead of a hung response plus process crash.
3. **Credential parsing on the digest/resource-binding paths** goes through a
   `deserializeCredentialSafely()` helper. A garbage `Authorization` header is
   semantically "no valid credential", so those routes now respond with the
   protocol-correct `402` + fresh challenge rather than a 400 (or, before this
   patch, a dead server).

## Verified

Before (main): `POST 'not json' -> /rpc` → connection dropped, process exits,
subsequent `/free` unreachable.

After (this branch), same server instance across all probes:

```
free: 200
bad rpc json: 400
rpc missing challenge: 400
garbage auth digest-binding: 402
garbage auth bind-resource: 402
free after all probes: 200
```

Regression: `python3 scripts/flow_runner.py --adapter typescript` →
**PASSED: 33 passed, 33 total** (golden untouched). `npx tsc --noEmit` reports
the identical pre-existing error set as main (23 = 23, all environmental
`@types/node` resolution noise; nothing new from this change).