### PR TITLE
fix(adapters): make base64url.decode reject invalid input everywhere

### DIFF
--- a/conformance/adapters/go/main.go
+++ b/conformance/adapters/go/main.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
@@ -208,6 +209,12 @@ func handleBase64URLDecode(input string) {
 	decoded, err := base64.RawURLEncoding.DecodeString(input)
 	if err != nil {
 		printJSON(commandResponse{Success: false, Error: err.Error(), ErrorType: "encoding_error"})
+		return
+	}
+	// The decode ABI returns a UTF-8 JSON string; bytes that cannot be
+	// decoded must be an encoding_error, not U+FFFD replacements.
+	if !utf8.Valid(decoded) {
+		printJSON(commandResponse{Success: false, Error: "decoded value is not valid UTF-8", ErrorType: "encoding_error"})
 		return
 	}
 	printJSON(commandResponse{Success: true, Result: string(decoded)})

--- a/conformance/adapters/python/adapter.py
+++ b/conformance/adapters/python/adapter.py
@@ -31,14 +31,21 @@ def base64url_encode(data: str) -> str:
 
 
 def base64url_decode(data: str) -> str:
-    """Decode a base64url string (with or without padding)."""
+    """Decode a base64url string (with or without padding).
+
+    Invalid input must be rejected, not repaired: silently dropping
+    out-of-alphabet characters would accept wire values every other
+    adapter refuses.
+    """
     import re
 
-    cleaned = re.sub(r"[^A-Za-z0-9_-]", "", data)
-    padding = 4 - (len(cleaned) % 4)
+    stripped = data.rstrip("=")
+    if re.search(r"[^A-Za-z0-9_-]", stripped):
+        raise ValueError("invalid base64url character")
+    padding = 4 - (len(stripped) % 4)
     if padding != 4:
-        cleaned += "=" * padding
-    decoded = base64.urlsafe_b64decode(cleaned)
+        stripped += "=" * padding
+    decoded = base64.urlsafe_b64decode(stripped)
     return decoded.decode("utf-8")
 
 
@@ -357,11 +364,11 @@ def main():
         else:
             print(json.dumps(error(f"Unknown command: {command}")))
     except Exception as e:
-        if command.startswith("parse-") or command == "base64url-decode":
+        if command.startswith("parse-"):
             error_type = "parse_error"
         elif command.startswith("format-"):
             error_type = "format_error"
-        elif command == "base64url-encode":
+        elif command.startswith("base64url-"):
             error_type = "encoding_error"
         elif command.startswith("generate-"):
             error_type = "generation_error"

--- a/conformance/adapters/ruby/adapter.rb
+++ b/conformance/adapters/ruby/adapter.rb
@@ -345,7 +345,7 @@ def run_adapter_request(request)
 end
 
 def error_type_for_command(command)
-  if command.start_with?("parse-") || command == "base64url-decode"
+  if command.start_with?("parse-")
     "parse_error"
   elsif command.start_with?("format-")
     "format_error"
@@ -393,7 +393,9 @@ def run_command(command, input)
   when "base64url-encode"
     success(base64url_encode(input))
   when "base64url-decode"
-    success(base64url_decode(input).force_encoding("UTF-8"))
+    decoded = base64url_decode(input).force_encoding("UTF-8")
+    raise ArgumentError, "decoded value is not valid UTF-8" unless decoded.valid_encoding?
+    success(decoded)
   when "generate-challenge-id"
     success(generate_conformance_challenge_id(JSON.parse(input)))
   when "cosign-tempo-fee-payer"

--- a/conformance/golden/adapter.ts
+++ b/conformance/golden/adapter.ts
@@ -101,7 +101,14 @@ function base64UrlEncode(value: string): string {
 }
 
 function base64UrlDecode(value: string): string {
-	return Buffer.from(value, 'base64url').toString('utf8')
+	// Buffer.from(value, 'base64url') silently ignores characters outside the
+	// alphabet, which would make the reference adapter accept wire values every
+	// other adapter rejects. Validate explicitly, and decode UTF-8 fatally so
+	// undecodable bytes error instead of turning into U+FFFD.
+	if (!/^[A-Za-z0-9_-]*={0,2}$/.test(value)) {
+		throw new Error('Invalid base64url character')
+	}
+	return new TextDecoder('utf-8', { fatal: true }).decode(Buffer.from(value, 'base64url'))
 }
 
 function generateConformanceChallengeId(params: {

--- a/conformance/vectors/base64url.json
+++ b/conformance/vectors/base64url.json
@@ -126,6 +126,30 @@
         "format": true,
         "roundtrip": true
       }
+    },
+    {
+      "name": "invalid_characters_rejected",
+      "description": "Characters outside the RFC4648 URL-safe alphabet are an encoding error, not silently dropped or ignored",
+      "tags": ["error-case"],
+      "encoded": "not-valid!!!",
+      "tests": {
+        "parse": {
+          "success": false,
+          "error_type": "encoding_error"
+        }
+      }
+    },
+    {
+      "name": "invalid_utf8_rejected",
+      "description": "Valid base64url whose bytes are not valid UTF-8 (0xFF) is an encoding error, not U+FFFD replacement output",
+      "tags": ["error-case"],
+      "encoded": "_w",
+      "tests": {
+        "parse": {
+          "success": false,
+          "error_type": "encoding_error"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
# Align `base64url.decode` failure semantics across all six adapters

## Where we are today

`operations.json` declares exactly one legal error type for `base64url.decode`
— `encoding_error` — yet the six adapters disagree three ways about what
invalid input even *is*:

**Axis 1: characters outside the URL-safe alphabet** (`"not-valid!!!"`)

| Adapter | Behavior on main |
|---|---|
| golden | **accepts** — `Buffer.from(value, 'base64url')` silently ignores foreign characters |
| python | **repairs** — `re.sub` strips foreign characters, then decodes what's left |
| ruby | errors, but as `parse_error` (undeclared for this op) |
| go / rust / java | `encoding_error` ✓ |

**Axis 2: valid base64url, bytes not valid UTF-8** (`"_w"` → `0xFF`)

| Adapter | Behavior on main |
|---|---|
| golden | succeeds with U+FFFD replacement output |
| go | succeeds with replacement bytes in the JSON result |
| python | errors, but as `parse_error` |
| ruby | `force_encoding("UTF-8")` produces an invalid string that blows up later in `JSON.generate` as `unknown_error` |
| rust / java | `encoding_error` ✓ |

So the same wire input can produce a success, a `parse_error`, an
`unknown_error`, or an `encoding_error` depending on which SDK you ask. The
reference adapter is among the *most* wrong (it manufactures data from garbage
input). Nothing catches this because the vector file only round-trips valid
data.

## What this PR changes

Target semantics — the strict behavior rust and java already implement, and
the only one compatible with the declared `errorTypes`:
reject foreign characters, reject undecodable bytes, always as `encoding_error`.

- **golden** — validate the alphabet before decoding; decode UTF-8 with
  `TextDecoder(..., { fatal: true })`.
- **python** — replace the character-stripping "repair" with validation;
  route `base64url-*` failures to `encoding_error` instead of lumping decode
  in with `parse_error`. (The helper's only caller is the decode command, so
  nothing else shifts.)
- **ruby** — move `base64url-decode` out of the `parse_error` bucket in
  `error_type_for_command`; add a `valid_encoding?` guard so invalid UTF-8
  fails as `encoding_error` at the operation instead of corrupting the
  response serialization.
- **go** — add a `utf8.Valid` check after decoding (alphabet rejection was
  already correct).

Two new error-case vectors, `invalid_characters_rejected` and
`invalid_utf8_rejected`, pin both axes for every adapter from now on.

## Verification

- typescript + python: full vector suites pass, including the two new
  scenarios (base64url vector: 64/64 across both adapters).
- ruby: local bundler cannot install the SDK gem in this environment, so the
  changed logic was exercised standalone (`Base64.urlsafe_decode64` +
  `valid_encoding?` + the new mapping): invalid chars → `encoding_error`,
  `0xFF` → `encoding_error`, round-trip unchanged. The gem is not involved in
  either changed path.
- go: not compilable here (go.mod wants a newer toolchain than this machine
  has); change is 6 lines against stdlib (`unicode/utf8`), `gofmt -e` clean.
  CI compiles it.
- rust / java: untouched; verified by reading `handle_base64url_decode` and
  `base64urlDecodeToString` that they already implement the target semantics,
  so the new vectors pass them as-is.