### PR TITLE
fix(runner): keep --output json parseable and contain vector-file crashes

### DIFF
--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -3,7 +3,12 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
+import json
+import tempfile
 import unittest
+from pathlib import Path
 
 from harness import AdapterConfig
 from vector_runner import VectorRunner
@@ -92,6 +97,61 @@ class VectorRunnerHelperTest(unittest.TestCase):
         }
 
         self.assertEqual(self.runner.scenario_wire(scenario), "abcbcbcd")
+
+
+class VectorRunnerJsonArtifactTest(unittest.TestCase):
+    """The json output format must stay machine-readable on stdout."""
+
+    def setUp(self) -> None:
+        self.runner = VectorRunner(output_format="json")
+        self.adapter = AdapterConfig(name="python", command=["python"], capabilities=[])
+
+    def run_vector_file_capturing_stdout(self, content: str) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            vector_path = Path(tmp) / "sample.json"
+            vector_path.write_text(content, encoding="utf-8")
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                self.runner.run_vector_file(self.adapter, vector_path)
+            return stdout.getvalue()
+
+    def test_vector_without_commands_does_not_write_to_stdout(self) -> None:
+        printed = self.run_vector_file_capturing_stdout(json.dumps({"scenarios": []}))
+
+        self.assertEqual(printed, "")
+
+    def test_missing_vector_file_does_not_write_to_stdout(self) -> None:
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            self.runner.run_vector_file(self.adapter, Path("/nonexistent/vectors/missing.json"))
+
+        self.assertEqual(stdout.getvalue(), "")
+
+    def test_malformed_vector_file_is_reported_not_fatal(self) -> None:
+        import vector_runner as vector_runner_module
+
+        fake_adapter = AdapterConfig(name="fake", command=["true"], capabilities=[])
+        with tempfile.TemporaryDirectory() as tmp:
+            vectors_dir = Path(tmp)
+            (vectors_dir / "broken.json").write_text("{not json", encoding="utf-8")
+
+            original_discover_vectors = vector_runner_module.discover_vector_files
+            original_discover_adapters = vector_runner_module.discover_adapters
+            vector_runner_module.discover_vector_files = lambda: {"broken": vectors_dir / "broken.json"}
+            vector_runner_module.discover_adapters = lambda: {"fake": fake_adapter}
+            try:
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    success = self.runner.run(adapter_names=["fake"], vector_names=["broken"])
+            finally:
+                vector_runner_module.discover_vector_files = original_discover_vectors
+                vector_runner_module.discover_adapters = original_discover_adapters
+
+        self.assertFalse(success)
+        output = json.loads(stdout.getvalue())
+        self.assertEqual(output["status"], "fail")
+        failing = [check for check in output["checks"] if check["status"] == "FAILURE"]
+        self.assertTrue(any("vector-file-error" in check["id"] for check in failing))
 
 
 if __name__ == "__main__":

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -298,9 +298,9 @@ class VectorRunner:
 
         if self.verbose:
             status = "✓" if passed else "✗"
-            print(f"    {status} {test_name}")
+            self.log(f"    {status} {test_name}")
             if not passed and error:
-                print(f"      {error}")
+                self.log(f"      {error}")
 
     def compare_results(
         self, expected: dict[str, Any], actual: dict[str, Any]
@@ -428,7 +428,7 @@ class VectorRunner:
         """Run all tests from a single vector file (v2 scenario format)."""
         vector_name = vector_path.stem
         if not vector_path.exists():
-            print(f"  ⚠ Vector file not found: {vector_path}")
+            self.log(f"  ⚠ Vector file not found: {vector_path}")
             return
 
         with open(vector_path) as f:
@@ -444,14 +444,14 @@ class VectorRunner:
         if operation:
             if operation not in adapter.capabilities:
                 if self.verbose:
-                    print(f"  {vector_name}.json SKIPPED ({adapter.name} lacks {operation})")
+                    self.log(f"  {vector_name}.json SKIPPED ({adapter.name} lacks {operation})")
                 return
         elif not parse_cmd and not format_cmd and not generate_cmd:
-            print(f"  ⚠ No commands defined in {vector_name}.json")
+            self.log(f"  ⚠ No commands defined in {vector_name}.json")
             return
 
         if self.verbose:
-            print(f"  {vector_name}.json")
+            self.log(f"  {vector_name}.json")
 
         is_base64url = parse_cmd and parse_cmd.startswith("base64url-")
         is_challenge_id = generate_cmd is not None
@@ -730,7 +730,20 @@ class VectorRunner:
                     self.log(f"  {vector_name}: SKIPPED (not found)")
                     continue
                 before_count = len(self.results)
-                self.run_vector_file(adapter, all_vectors[vector_name], tag_filter=tag_filter)
+                try:
+                    self.run_vector_file(adapter, all_vectors[vector_name], tag_filter=tag_filter)
+                except Exception as exc:
+                    self._record_result(
+                        vector_file=vector_name,
+                        test_type=TestType.BUILD,
+                        test_name="vector_file_error",
+                        adapter=adapter.name,
+                        passed=False,
+                        description="Vector file loads and its scenarios run without crashing the runner",
+                        expected="vector file parses and runs",
+                        actual=None,
+                        error=f"{type(exc).__name__}: {exc}",
+                    )
                 # Print results for this vector file
                 for r in self.results[before_count:]:
                     status = "PASS" if r.passed else "FAIL"


### PR DESCRIPTION
# vector_runner: keep `--output json` machine-readable and survive malformed vector files

CI consumes this runner's stdout as a JSON artifact:

```
vector_runner.py --output json > results-<adapter>.json
```

Two failure modes can silently destroy that artifact today.

## 1. Stray `print()` calls bypass the json guard

`VectorRunner.log()` exists precisely to suppress human-readable output when
`output_format == "json"`, but `run_vector_file()` and `_record_result()` still
call `print()` directly in a few places (missing vector file, vector file with
no `commands`, and the verbose per-test lines). Any of those lines lands in
front of the JSON document, so `merge_vector_results.py` fails to parse the
artifact and the adapter's entire pass/fail breakdown collapses into a single
"Could not read results" failure.

All of these call sites now go through `self.log()`, which is a no-op in json
mode and unchanged in text mode.

## 2. A malformed vector file aborts the whole run

`run()` invoked `run_vector_file()` unguarded. One vector file with invalid
JSON — or a scenario missing a required key like `input` or `expected` —
raised straight out of `main()`, so in json mode *nothing* was written to
stdout and every check that had already run was lost.

Per-adapter and per-operation errors were already contained
(`run_adapter` / `run_operation_timed` catch exceptions and record failures);
file-level errors are now contained the same way: the runner records a failing
`vector_file_error` check for that file and keeps going, and the overall run
correctly reports `fail`.

## Verification

```
$ python3 scripts/test_vector_runner.py
Ran 9 tests ... OK            # 6 existing + 3 new
$ python3 scripts/vector_runner.py --adapter typescript --vector base64url --output json | python3 -m json.tool
# parses cleanly, status "pass", 30 checks
```

The new tests pin down: no stdout leakage for command-less vectors, no stdout
leakage for missing vector files, and a malformed vector file producing a
failing check (not a crash