### PR TITLE
fix(runners): fail instead of passing when zero checks execute

### DIFF
--- a/conformance/scripts/flow_runner.py
+++ b/conformance/scripts/flow_runner.py
@@ -637,6 +637,16 @@ def record_adapter_failure(results: list[RunResult], adapter: str, exc: Exceptio
     results.append(RunResult(adapter=adapter, name="adapter-run", passed=False, error=str(exc)))
 
 
+def guard_no_results(results: list[RunResult], adapter: str) -> None:
+    """An empty result set must fail: zero executed checks is not conformance."""
+    if not results:
+        record_adapter_failure(
+            results,
+            adapter,
+            RuntimeError("No flow conformance checks were executed"),
+        )
+
+
 def compare_results(
     expected: list[dict[str, Any]],
     actual: list[dict[str, Any]],
@@ -752,6 +762,8 @@ def main() -> int:
             except Exception as exc:
                 log(" failed", args.output)
                 record_adapter_failure(results, adapter_name, exc)
+
+        guard_no_results(results, args.adapter)
 
         passed = sum(1 for r in results if r.passed)
         failed = sum(1 for r in results if not r.passed)

--- a/conformance/scripts/server_verify_runner.py
+++ b/conformance/scripts/server_verify_runner.py
@@ -57,6 +57,17 @@ def selected_adapters(name: str, adapters: dict[str, AdapterConfig]) -> list[str
     return selected
 
 
+def guard_no_results(results: list[RunResult], adapter: str) -> None:
+    """An empty result set must fail: zero executed checks is not conformance."""
+    if not results:
+        results.append(RunResult(
+            adapter=adapter,
+            name="no-checks",
+            passed=False,
+            error="No server verification checks were executed",
+        ))
+
+
 def run_adapter(adapter: AdapterConfig, cases: list[dict[str, Any]]) -> list[RunResult]:
     build_error = build_adapter(adapter)
     if build_error:
@@ -117,6 +128,8 @@ def main() -> int:
         except Exception as exc:
             print(" failed")
             results.append(RunResult(adapter=adapter_name, name="adapter-run", passed=False, error=str(exc)))
+
+    guard_no_results(results, args.adapter)
 
     passed = sum(1 for result in results if result.passed)
     failed = sum(1 for result in results if not result.passed)

--- a/conformance/scripts/test_runner_guards.py
+++ b/conformance/scripts/test_runner_guards.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Tests for the zero-check guards shared by the flow and server-verify runners."""
+
+from __future__ import annotations
+
+import unittest
+
+import flow_runner
+import server_verify_runner
+
+
+class FlowRunnerGuardTest(unittest.TestCase):
+    def test_empty_results_become_a_failure(self) -> None:
+        results: list[flow_runner.RunResult] = []
+
+        flow_runner.guard_no_results(results, "all")
+
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].passed)
+        self.assertIn("No flow conformance checks", results[0].error or "")
+
+    def test_existing_results_are_untouched(self) -> None:
+        results = [flow_runner.RunResult(adapter="go", name="free-endpoint", passed=True)]
+
+        flow_runner.guard_no_results(results, "all")
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].passed)
+
+
+class ServerVerifyRunnerGuardTest(unittest.TestCase):
+    def test_empty_results_become_a_failure(self) -> None:
+        results: list[server_verify_runner.RunResult] = []
+
+        server_verify_runner.guard_no_results(results, "all")
+
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].passed)
+        self.assertIn("No server verification checks", results[0].error or "")
+
+    def test_existing_failure_is_not_duplicated(self) -> None:
+        results = [server_verify_runner.RunResult(adapter="go", name="case", passed=False, error="boom")]
+
+        server_verify_runner.guard_no_results(results, "all")
+
+        self.assertEqual(len(results), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Fail flow and server-verify runs that execute zero checks

## Problem

`vector_runner.py` refuses to report success when nothing ran (it records an
explicit `no_checks` failure), but the other two runners have no such guard:

- `flow_runner.py` — `selected_adapters("all", ...)` excludes `typescript`
  (it is the golden), so on a checkout where only the TypeScript adapter is
  discovered the loop body never executes. `passed=0, failed=0` prints
  `PASSED: 0 passed, 0 total` and exits 0. The same happens if
  `golden-results.json` and the adapter both produce empty result lists.
- `server_verify_runner.py` — an empty `cases` array in
  `server-verification/cases.json` (e.g. a truncated fixture) makes every
  adapter return `[]`, and the run exits 0 with `PASSED: 0 passed, 0 total`.

In both cases CI treats the green exit code as conformance evidence when in
fact nothing was verified.

## Fix

Add a `guard_no_results()` step to both runners, invoked after the adapter
loop and before the summary: when the result list is empty it appends a
failing synthetic result (`No flow conformance checks were executed` /
`No server verification checks were executed`), which flows through the
existing text/JSON reporting and flips the exit code to 1. Runs that produce
any real result — pass or fail — are unaffected, as is `--update-golden`.

This mirrors the `no_checks` behavior the vector runner has had since the
structured-checks change (#32), closing the gap for the other two suites.

## Test plan

- New `test_runner_guards.py` covering both guards (empty list → failure;
  non-empty list untouched). Discovered automatically by the ci.yml
  `unittest discover` step. 4 tests, OK.
- Full script suite still green: `python3 -m unittest discover -s scripts -p "test_*.py"`.