### PR TITLE
chore: batch Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,65 +1,45 @@
 version: 2
 
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/conformance"
-    schedule:
-      interval: "weekly"
-    groups:
-      npm-dependencies:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
 
   - package-ecosystem: "cargo"
     directory: "/conformance/adapters/rust"
-    schedule:
-      interval: "weekly"
-    groups:
-      rust-dependencies:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
 
   - package-ecosystem: "uv"
     directory: "/conformance/adapters/python"
-    schedule:
-      interval: "weekly"
-    groups:
-      python-dependencies:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
 
   - package-ecosystem: "gomod"
     directory: "/conformance/adapters/go"
-    schedule:
-      interval: "weekly"
-    groups:
-      go-dependencies:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
 
   - package-ecosystem: "bundler"
     directory: "/conformance/adapters/ruby"
-    schedule:
-      interval: "weekly"
-    groups:
-      ruby-dependencies:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
 
   - package-ecosystem: "gradle"
     directory: "/conformance/adapters/java"
-    schedule:
-      interval: "weekly"
-    groups:
-      java-dependencies:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"
 
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      interval: "weekly"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
+    patterns: ["*"]
+    multi-ecosystem-group: "weekly-dependencies"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,107 @@
+name: Dependabot
+
+on:
+  workflow_call:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-${{ github.repository }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  merge:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+
+      - name: Wait for checks
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          previous_signature=""
+          stable_passes=0
+
+          for _ in $(seq 1 180); do
+            current_head=$(gh pr view "$PR_URL" --json headRefOid --jq .headRefOid)
+            if [ "$current_head" != "$HEAD_SHA" ]; then
+              echo "Pull request head changed while checks were running"
+              exit 1
+            fi
+
+            set +e
+            checks=$(gh pr checks "$PR_URL" --json bucket,name,workflow)
+            check_status=$?
+            set -e
+            if [ "$check_status" -ne 0 ] && [ "$check_status" -ne 8 ]; then
+              exit "$check_status"
+            fi
+
+            relevant=$(jq '[.[] | select(.workflow != "Dependabot")]' <<<"$checks")
+            count=$(jq 'length' <<<"$relevant")
+            failures=$(jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' <<<"$relevant")
+            pending=$(jq '[.[] | select(.bucket == "pending")] | length' <<<"$relevant")
+            signature=$(jq -r '[.[] | (.workflow + "/" + .name)] | sort | join("\n")' <<<"$relevant")
+
+            if [ "$failures" -gt 0 ]; then
+              echo "At least one pull request check failed or was cancelled"
+              jq . <<<"$relevant"
+              exit 1
+            fi
+
+            if [ "$count" -gt 0 ] && [ "$pending" -eq 0 ]; then
+              if [ "$signature" = "$previous_signature" ]; then
+                stable_passes=$((stable_passes + 1))
+              else
+                stable_passes=1
+              fi
+
+              if [ "$stable_passes" -ge 3 ]; then
+                jq . <<<"$relevant"
+                exit 0
+              fi
+            else
+              stable_passes=0
+            fi
+
+            previous_signature="$signature"
+            sleep 10
+          done
+
+          echo "Timed out waiting for pull request checks"
+          exit 1
+
+      - name: Approve update
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review "$PR_URL" --approve
+
+      - name: Merge update
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --squash --match-head-commit "$HEAD_SHA"


### PR DESCRIPTION
## Motivation

Routine dependency updates currently arrive as separate pull requests for each package ecosystem, creating avoidable review overhead across MPP repositories.

## Summary

- Batch routine updates from all configured ecosystems into one weekly pull request
- Add a reusable Dependabot workflow for MPP repositories
- Automatically squash-merge patch and minor updates after every pull request check passes
- Keep major updates manual and security updates independent of the weekly version-update schedule

## Key design considerations

- Validate Dependabot metadata and the unchanged pull request head before merging
- Wait for a stable, fully passing check set because required checks are not configured consistently across repositories
- Never check out pull request code from the privileged `pull_request_target` workflow
- Allow consumer repositories to pin the reusable workflow to an exact commit