### PR TITLE
fix: use safe Dependabot trigger

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,7 +2,7 @@ name: Dependabot
 
 on:
   workflow_call:
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:


### PR DESCRIPTION
## Motivation

The shared Dependabot workflow uses `pull_request_target`, which fails GitHub Actions security scanning and grants unnecessary privileges to a risky trigger.

## Summary

- Replace `pull_request_target` with `pull_request`
- Preserve the existing Dependabot-only guard and merge policy

## Key design considerations

- Keep Dependabot metadata available to the reusable workflow
- Retain explicit least-privilege job permissions
- Avoid checking out or executing pull request code in the merge workflow