### PR TITLE
feat(conformance): add SDK version constraints

### DIFF
--- a/conformance/HARNESS_SPEC.md
+++ b/conformance/HARNESS_SPEC.md
@@ -605,7 +605,7 @@ for vector in vectors:
 npm-style SemVer constraints with `=`, `<`, `<=`, `>`, or `>=`; whitespace-
 separated comparators are combined with AND. Adapters not named in the object
 remain applicable. Invalid expressions and non-SemVer installed versions are
-runner errors, not skips.
+runner errors, not skips. Unknown adapter keys are also runner errors.
 
 Flow pseudo-code:
 

--- a/conformance/HARNESS_SPEC.md
+++ b/conformance/HARNESS_SPEC.md
@@ -594,10 +594,18 @@ for manifest in discover("adapters/*/adapter.json"):
 
 for vector in vectors:
     for scenario in vector.scenarios:
+        if not matches_sdk_version(adapter, scenario.sdkVersions):
+            continue
         for op, input_value, expected in expand_scenario(vector, scenario):
             actual = adapter.call(op, input_value)
             compare(normalize(expected), normalize(actual))
 ```
+
+`scenario.sdkVersions` is an optional object keyed by adapter name. Values are
+SemVer comparator expressions using `=`, `==`, `<`, `<=`, `>`, or `>=`;
+whitespace- or comma-separated comparators are combined with AND. Adapters not
+named in the object remain applicable. Invalid expressions and non-SemVer
+installed versions are runner errors, not skips.
 
 Flow pseudo-code:
 

--- a/conformance/HARNESS_SPEC.md
+++ b/conformance/HARNESS_SPEC.md
@@ -601,11 +601,11 @@ for vector in vectors:
             compare(normalize(expected), normalize(actual))
 ```
 
-`scenario.sdkVersions` is an optional object keyed by adapter name. Values are
-SemVer comparator expressions using `=`, `==`, `<`, `<=`, `>`, or `>=`;
-whitespace- or comma-separated comparators are combined with AND. Adapters not
-named in the object remain applicable. Invalid expressions and non-SemVer
-installed versions are runner errors, not skips.
+`scenario.sdkVersions` is an optional object keyed by adapter name. Values use
+npm-style SemVer constraints with `=`, `<`, `<=`, `>`, or `>=`; whitespace-
+separated comparators are combined with AND. Adapters not named in the object
+remain applicable. Invalid expressions and non-SemVer installed versions are
+runner errors, not skips.
 
 Flow pseudo-code:
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -72,7 +72,7 @@ Use `sdkVersions` when a rule only applies to particular released SDK versions:
 }
 ```
 
-Constraints use npm-style SemVer syntax with `=`, `<`, `<=`, `>`, and `>=`. Whitespace-separated comparators are combined with AND. An adapter not named in `sdkVersions` still runs the scenario; combine `sdkVersions` with `adapters` to restrict both adapter and version. Invalid constraints or installed versions fail the suite instead of silently skipping coverage. Java commit pins are not SemVer and cannot use `sdkVersions` until a versioned release is pinned.
+Constraints use npm-style SemVer syntax with `=`, `<`, `<=`, `>`, and `>=`. Whitespace-separated comparators are combined with AND. An adapter not named in `sdkVersions` still runs the scenario; combine `sdkVersions` with `adapters` to restrict both adapter and version. Unknown adapter keys, invalid constraints, and non-SemVer installed versions fail the suite instead of silently skipping coverage. Java constraints use the released version pinned in `adapters/java/build.gradle`.
 
 ### Test Types
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -60,6 +60,20 @@ Each vector file contains **scenarios** — individual test cases with a name, d
 
 Scenarios may optionally include `adapters` to restrict an edge case to specific SDK adapters, and `maxDurationMs` or `maxDurationMsByAdapter` to assert bounded execution for parser stress cases. Long stress inputs can use `wire` as `{ "prefix": "...", "repeat": "...", "count": 123, "suffix": "..." }` to keep fixtures reviewable.
 
+Use `sdkVersions` when a rule only applies to particular released SDK versions:
+
+```json
+{
+  "name": "rejects_weak_secret",
+  "sdkVersions": {
+    "typescript": ">0.8.15",
+    "rust": ">=0.12.0, <1.0.0"
+  }
+}
+```
+
+Supported SemVer comparators are `=`, `==`, `<`, `<=`, `>`, and `>=`. Multiple comparators separated by whitespace or commas are combined with AND. An adapter not named in `sdkVersions` still runs the scenario; combine `sdkVersions` with `adapters` to restrict both adapter and version. Invalid constraints or installed versions fail the suite instead of silently skipping coverage. Java commit pins are not SemVer and cannot use `sdkVersions` until a versioned release is pinned.
+
 ### Test Types
 
 | Test | What It Checks |
@@ -275,8 +289,9 @@ make flow-sdk ADAPTER=rust
 
 1. Edit the appropriate vector file in `vectors/`
 2. Add a new scenario object to the `scenarios` array
-3. Run `make test` to verify all adapters pass
-4. Submit a PR
+3. Optionally use `adapters` and `sdkVersions` to define where the rule applies
+4. Run `make test` to verify all applicable adapters pass
+5. Submit a PR
 
 ## Prerequisites
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -67,12 +67,12 @@ Use `sdkVersions` when a rule only applies to particular released SDK versions:
   "name": "rejects_weak_secret",
   "sdkVersions": {
     "typescript": ">0.8.15",
-    "rust": ">=0.12.0, <1.0.0"
+    "rust": ">=0.12.0 <1.0.0"
   }
 }
 ```
 
-Supported SemVer comparators are `=`, `==`, `<`, `<=`, `>`, and `>=`. Multiple comparators separated by whitespace or commas are combined with AND. An adapter not named in `sdkVersions` still runs the scenario; combine `sdkVersions` with `adapters` to restrict both adapter and version. Invalid constraints or installed versions fail the suite instead of silently skipping coverage. Java commit pins are not SemVer and cannot use `sdkVersions` until a versioned release is pinned.
+Constraints use npm-style SemVer syntax with `=`, `<`, `<=`, `>`, and `>=`. Whitespace-separated comparators are combined with AND. An adapter not named in `sdkVersions` still runs the scenario; combine `sdkVersions` with `adapters` to restrict both adapter and version. Invalid constraints or installed versions fail the suite instead of silently skipping coverage. Java commit pins are not SemVer and cannot use `sdkVersions` until a versioned release is pinned.
 
 ### Test Types
 

--- a/conformance/requirements.txt
+++ b/conformance/requirements.txt
@@ -1,2 +1,3 @@
 deepdiff>=6.0.0
 jsonschema>=4.0.0
+semantic-version>=2.10.0,<3.0.0

--- a/conformance/scripts/merge_vector_results.py
+++ b/conformance/scripts/merge_vector_results.py
@@ -57,6 +57,7 @@ def main() -> int:
         "num_checks": 0,
         "passed": 0,
         "failed": 0,
+        "skipped": 0,
         "errors": [],
     }
     errors = merged["errors"]
@@ -84,6 +85,7 @@ def main() -> int:
 
         merged["passed"] = int(merged["passed"]) + int(result.get("passed", 0))
         merged["failed"] = int(merged["failed"]) + int(result.get("failed", 0))
+        merged["skipped"] = int(merged["skipped"]) + int(result.get("skipped", 0))
         merged["num_checks"] = int(merged["num_checks"]) + int(result.get("num_checks", 0))
         errors.extend(result.get("errors", []))
 

--- a/conformance/scripts/sdk_version.py
+++ b/conformance/scripts/sdk_version.py
@@ -102,6 +102,15 @@ VERSIONS = {
 }
 
 
+def installed_version(adapter: str) -> str:
+    """Return only the installed SDK version for constraint evaluation."""
+    summary = VERSIONS[adapter]()
+    _, separator, version = summary.rpartition("@")
+    if not separator or not version:
+        raise RuntimeError(f"Could not parse SDK version from {summary!r}")
+    return version
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--adapter", required=True, choices=sorted(VERSIONS))

--- a/conformance/scripts/test_sdk_version.py
+++ b/conformance/scripts/test_sdk_version.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Tests for SDK version reporting helpers."""
+
+from __future__ import annotations
+
+import unittest
+
+import sdk_version
+
+
+class InstalledVersionTest(unittest.TestCase):
+    def test_extracts_version_from_summary(self) -> None:
+        original = sdk_version.VERSIONS["python"]
+        sdk_version.VERSIONS["python"] = lambda: "pympp@0.9.1"
+        try:
+            self.assertEqual(sdk_version.installed_version("python"), "0.9.1")
+        finally:
+            sdk_version.VERSIONS["python"] = original
+
+    def test_rejects_malformed_summary(self) -> None:
+        original = sdk_version.VERSIONS["python"]
+        sdk_version.VERSIONS["python"] = lambda: "pympp"
+        try:
+            with self.assertRaisesRegex(RuntimeError, "Could not parse SDK version"):
+                sdk_version.installed_version("python")
+        finally:
+            sdk_version.VERSIONS["python"] = original
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conformance/scripts/test_use_local_sdk.py
+++ b/conformance/scripts/test_use_local_sdk.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Tests for local SDK adapter configuration."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from use_local_sdk import configure_go, go_sdk_version
+
+
+class GoSdkVersionTest(unittest.TestCase):
+    def test_reads_declared_checkout_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdk_path = Path(tmp)
+            (sdk_path / "go.mod").write_text(
+                "// changelogs:version 0.3.0\nmodule github.com/tempoxyz/mpp-go\n",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(go_sdk_version(sdk_path), "v0.3.0")
+
+    def test_requires_declared_checkout_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sdk_path = Path(tmp)
+            (sdk_path / "go.mod").write_text(
+                "module github.com/tempoxyz/mpp-go\n", encoding="utf-8"
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "changelogs:version"):
+                go_sdk_version(sdk_path)
+
+    def test_configures_adapter_requirement_to_checkout_version(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            conformance_dir = root / "conformance"
+            adapter_dir = conformance_dir / "adapters" / "go"
+            adapter_dir.mkdir(parents=True)
+            sdk_path = root / "sdk"
+            sdk_path.mkdir()
+            (sdk_path / "go.mod").write_text(
+                "// changelogs:version 0.3.0\nmodule github.com/tempoxyz/mpp-go\n",
+                encoding="utf-8",
+            )
+            completed = subprocess.CompletedProcess([], 0, "", "")
+
+            with patch("use_local_sdk.subprocess.run", return_value=completed) as run:
+                configure_go(conformance_dir, sdk_path)
+
+            edit_command = run.call_args_list[0].args[0]
+            self.assertIn(
+                "github.com/tempoxyz/mpp-go@v0.3.0",
+                edit_command,
+            )
+            self.assertIn(
+                f"github.com/tempoxyz/mpp-go={sdk_path}",
+                edit_command,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -90,10 +90,24 @@ class VectorRunnerHelperTest(unittest.TestCase):
                 {"sdkVersions": ">=0.9.0"}, self.adapter
             )
 
+    def test_scenario_version_constraints_reject_unknown_adapter(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "sdkVersions contains unknown adapter keys: pyhton"
+        ):
+            self.runner.scenario_version_applies(
+                {"sdkVersions": {"pyhton": ">=0.9.0"}}, self.adapter
+            )
+
     def test_scenario_version_constraint_requires_a_string(self) -> None:
         with self.assertRaisesRegex(ValueError, "sdkVersions.python must be a string"):
             self.runner.scenario_version_applies(
                 {"sdkVersions": {"python": 0.9}}, self.adapter
+            )
+
+    def test_scenario_version_constraints_validate_every_adapter_value(self) -> None:
+        with self.assertRaisesRegex(ValueError, "sdkVersions.rust must be a string"):
+            self.runner.scenario_version_applies(
+                {"sdkVersions": {"rust": 0.12}}, self.adapter
             )
 
     def test_run_vector_file_skips_nonmatching_sdk_version(self) -> None:
@@ -115,6 +129,7 @@ class VectorRunnerHelperTest(unittest.TestCase):
             self.runner.run_vector_file(self.adapter, vector_path)
 
         self.assertEqual(self.runner.results, [])
+        self.assertEqual(self.runner.version_skips, 1)
 
     def test_compare_adapter_response_checks_error_message_substring(self) -> None:
         expected = {
@@ -228,6 +243,47 @@ class VectorRunnerJsonArtifactTest(unittest.TestCase):
         self.assertEqual(output["status"], "fail")
         failing = [check for check in output["checks"] if check["status"] == "FAILURE"]
         self.assertTrue(any("vector-file-error" in check["id"] for check in failing))
+
+    def test_all_version_skipped_selection_passes(self) -> None:
+        import vector_runner as vector_runner_module
+
+        fake_adapter = AdapterConfig(name="fake", command=["true"], capabilities=[])
+        vector = {
+            "commands": {"parse": "parse-www-authenticate"},
+            "scenarios": [
+                {
+                    "name": "future_rule",
+                    "wire": "unused",
+                    "tests": {"parse": True},
+                    "sdkVersions": {"fake": ">0.9.1"},
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            vector_path = Path(tmp) / "future.json"
+            vector_path.write_text(json.dumps(vector), encoding="utf-8")
+            original_discover_vectors = vector_runner_module.discover_vector_files
+            original_discover_adapters = vector_runner_module.discover_adapters
+            vector_runner_module.discover_vector_files = lambda: {"future": vector_path}
+            vector_runner_module.discover_adapters = lambda: {"fake": fake_adapter}
+            runner = VectorRunner(
+                output_format="json", sdk_version_resolver=lambda _: "0.9.1"
+            )
+            try:
+                stdout = io.StringIO()
+                with contextlib.redirect_stdout(stdout):
+                    success = runner.run(
+                        adapter_names=["fake"], vector_names=["future"]
+                    )
+            finally:
+                vector_runner_module.discover_vector_files = original_discover_vectors
+                vector_runner_module.discover_adapters = original_discover_adapters
+
+        self.assertTrue(success)
+        output = json.loads(stdout.getvalue())
+        self.assertEqual(output["status"], "pass")
+        self.assertEqual(output["num_checks"], 0)
+        self.assertEqual(output["skipped"], 1)
 
 
 if __name__ == "__main__":

--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -91,9 +91,7 @@ class VectorRunnerHelperTest(unittest.TestCase):
             )
 
     def test_scenario_version_constraint_requires_a_string(self) -> None:
-        with self.assertRaisesRegex(
-            ValueError, "sdkVersions.python must be a string"
-        ):
+        with self.assertRaisesRegex(ValueError, "sdkVersions.python must be a string"):
             self.runner.scenario_version_applies(
                 {"sdkVersions": {"python": 0.9}}, self.adapter
             )

--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -49,7 +49,7 @@ class VectorRunnerHelperTest(unittest.TestCase):
         self.assertEqual(error, "duration exceeded: expected <= 5000 ms, got 5000.1 ms")
 
     def test_scenario_version_constraint_applies_when_matching(self) -> None:
-        scenario = {"sdkVersions": {"python": ">0.9.0, <1.0.0"}}
+        scenario = {"sdkVersions": {"python": ">0.9.0 <1.0.0"}}
 
         applies, reason = self.runner.scenario_version_applies(scenario, self.adapter)
 

--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -16,7 +16,15 @@ from vector_runner import VectorRunner
 
 class VectorRunnerHelperTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.runner = VectorRunner(output_format="json")
+        self.resolved_adapters: list[str] = []
+
+        def resolve_version(adapter: str) -> str:
+            self.resolved_adapters.append(adapter)
+            return "0.9.1"
+
+        self.runner = VectorRunner(
+            output_format="json", sdk_version_resolver=resolve_version
+        )
         self.adapter = AdapterConfig(name="python", command=["python"], capabilities=[])
 
     def test_duration_limit_prefers_adapter_specific_value(self) -> None:
@@ -39,6 +47,76 @@ class VectorRunnerHelperTest(unittest.TestCase):
 
         self.assertFalse(passed)
         self.assertEqual(error, "duration exceeded: expected <= 5000 ms, got 5000.1 ms")
+
+    def test_scenario_version_constraint_applies_when_matching(self) -> None:
+        scenario = {"sdkVersions": {"python": ">0.9.0, <1.0.0"}}
+
+        applies, reason = self.runner.scenario_version_applies(scenario, self.adapter)
+
+        self.assertTrue(applies)
+        self.assertIsNone(reason)
+        self.assertEqual(self.resolved_adapters, ["python"])
+
+    def test_scenario_version_constraint_skips_when_not_matching(self) -> None:
+        scenario = {"sdkVersions": {"python": ">0.9.1"}}
+
+        applies, reason = self.runner.scenario_version_applies(scenario, self.adapter)
+
+        self.assertFalse(applies)
+        self.assertEqual(reason, "python@0.9.1 does not satisfy >0.9.1")
+
+    def test_scenario_version_constraint_ignores_unspecified_adapter(self) -> None:
+        scenario = {"sdkVersions": {"rust": ">=0.12.0"}}
+
+        applies, reason = self.runner.scenario_version_applies(scenario, self.adapter)
+
+        self.assertTrue(applies)
+        self.assertIsNone(reason)
+        self.assertEqual(self.resolved_adapters, [])
+
+    def test_scenario_version_resolver_is_cached_per_adapter(self) -> None:
+        scenario = {"sdkVersions": {"python": ">=0.9.0"}}
+
+        self.runner.scenario_version_applies(scenario, self.adapter)
+        self.runner.scenario_version_applies(scenario, self.adapter)
+
+        self.assertEqual(self.resolved_adapters, ["python"])
+
+    def test_scenario_version_constraints_require_an_object(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "sdkVersions must be an object keyed by adapter name"
+        ):
+            self.runner.scenario_version_applies(
+                {"sdkVersions": ">=0.9.0"}, self.adapter
+            )
+
+    def test_scenario_version_constraint_requires_a_string(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "sdkVersions.python must be a string"
+        ):
+            self.runner.scenario_version_applies(
+                {"sdkVersions": {"python": 0.9}}, self.adapter
+            )
+
+    def test_run_vector_file_skips_nonmatching_sdk_version(self) -> None:
+        vector = {
+            "commands": {"parse": "parse-www-authenticate"},
+            "scenarios": [
+                {
+                    "name": "future_rule",
+                    "wire": "unused",
+                    "tests": {"parse": True},
+                    "sdkVersions": {"python": ">0.9.1"},
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            vector_path = Path(tmp) / "sample.json"
+            vector_path.write_text(json.dumps(vector), encoding="utf-8")
+
+            self.runner.run_vector_file(self.adapter, vector_path)
+
+        self.assertEqual(self.runner.results, [])
 
     def test_compare_adapter_response_checks_error_message_substring(self) -> None:
         expected = {

--- a/conformance/scripts/test_version_constraints.py
+++ b/conformance/scripts/test_version_constraints.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Tests for SemVer conformance scenario constraints."""
+
+from __future__ import annotations
+
+import unittest
+
+from version_constraints import SemVer, matches_constraint
+
+
+class VersionConstraintTest(unittest.TestCase):
+    def test_comparators(self) -> None:
+        cases = [
+            ("1.2.3", "=1.2.3", True),
+            ("1.2.3", "==1.2.3", True),
+            ("1.2.3", "<1.2.4", True),
+            ("1.2.3", "<=1.2.3", True),
+            ("1.2.3", ">1.2.2", True),
+            ("1.2.3", ">=1.2.3", True),
+            ("1.2.3", ">1.2.3", False),
+            ("1.2.3", ">=1.2.0, <2.0.0", True),
+            ("1.2.3", ">=1.2.0 <1.2.3", False),
+            ("v1.2.3", "=1.2.3", True),
+            ("1.2.3+build.7", "=1.2.3", True),
+            ("1.2.3-alpha.1", "<1.2.3", True),
+            ("1.2.3-alpha.2", ">1.2.3-alpha.1", True),
+            ("1.2.3-alpha", ">1.2.3-1", True),
+        ]
+
+        for version, constraint, expected in cases:
+            with self.subTest(version=version, constraint=constraint):
+                self.assertEqual(matches_constraint(version, constraint), expected)
+
+    def test_invalid_versions(self) -> None:
+        for version in ["1", "1.2", "1.02.3", "1.2.3-01", "not-a-version"]:
+            with self.subTest(version=version):
+                with self.assertRaisesRegex(ValueError, "Invalid SemVer version"):
+                    SemVer.parse(version)
+
+    def test_invalid_constraints(self) -> None:
+        constraints = [
+            "",
+            "1.2.3",
+            "=>1.2.3",
+            ">=1.2",
+            ", >=1.2.3",
+            ">=1.2.3,",
+        ]
+        for constraint in constraints:
+            with self.subTest(constraint=constraint):
+                with self.assertRaisesRegex(ValueError, "constraint"):
+                    matches_constraint("1.2.3", constraint)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conformance/scripts/test_version_constraints.py
+++ b/conformance/scripts/test_version_constraints.py
@@ -5,20 +5,19 @@ from __future__ import annotations
 
 import unittest
 
-from version_constraints import SemVer, matches_constraint
+from version_constraints import matches_constraint
 
 
 class VersionConstraintTest(unittest.TestCase):
     def test_comparators(self) -> None:
         cases = [
             ("1.2.3", "=1.2.3", True),
-            ("1.2.3", "==1.2.3", True),
             ("1.2.3", "<1.2.4", True),
             ("1.2.3", "<=1.2.3", True),
             ("1.2.3", ">1.2.2", True),
             ("1.2.3", ">=1.2.3", True),
             ("1.2.3", ">1.2.3", False),
-            ("1.2.3", ">=1.2.0, <2.0.0", True),
+            ("1.2.3", ">=1.2.0 <2.0.0", True),
             ("1.2.3", ">=1.2.0 <1.2.3", False),
             ("v1.2.3", "=1.2.3", True),
             ("1.2.3+build.7", "=1.2.3", True),
@@ -35,16 +34,14 @@ class VersionConstraintTest(unittest.TestCase):
         for version in ["1", "1.2", "1.02.3", "1.2.3-01", "not-a-version"]:
             with self.subTest(version=version):
                 with self.assertRaisesRegex(ValueError, "Invalid SemVer version"):
-                    SemVer.parse(version)
+                    matches_constraint(version, ">=1.0.0")
 
     def test_invalid_constraints(self) -> None:
         constraints = [
             "",
-            "1.2.3",
+            "==1.2.3",
             "=>1.2.3",
-            ">=1.2",
-            ", >=1.2.3",
-            ">=1.2.3,",
+            ">=1.2.3,<2.0.0",
         ]
         for constraint in constraints:
             with self.subTest(constraint=constraint):

--- a/conformance/scripts/use_local_sdk.py
+++ b/conformance/scripts/use_local_sdk.py
@@ -71,15 +71,26 @@ def configure_python(conformance_dir: Path, sdk_path: Path) -> None:
     )
 
 
+def go_sdk_version(sdk_path: Path) -> str:
+    go_mod = read_text(sdk_path / "go.mod")
+    match = re.search(r"^// changelogs:version\s+(v?\S+)\s*$", go_mod, re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"Could not find changelogs:version in {sdk_path / 'go.mod'}")
+    return match.group(1) if match.group(1).startswith("v") else f"v{match.group(1)}"
+
+
 def configure_go(conformance_dir: Path, sdk_path: Path) -> None:
     adapter_dir = conformance_dir / "adapters" / "go"
     go_env = os.environ.copy()
     go_env.setdefault("GOTOOLCHAIN", "auto")
+    sdk_version = go_sdk_version(sdk_path)
     result = subprocess.run(
         [
             "go",
             "mod",
             "edit",
+            "-require",
+            f"github.com/tempoxyz/mpp-go@{sdk_version}",
             "-replace",
             f"github.com/tempoxyz/mpp-go={sdk_path}",
         ],

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -181,6 +181,8 @@ class VectorRunner:
         self.results: list[TestResult] = []
         self.sdk_version_resolver = sdk_version_resolver or installed_version
         self.sdk_versions: dict[str, str] = {}
+        self.known_adapter_names: set[str] | None = None
+        self.version_skips = 0
     
     def log(self, msg: str, end: str = "\n", flush: bool = False) -> None:
         """Print message only if output format is text."""
@@ -230,20 +232,33 @@ class VectorRunner:
         value = scenario.get("maxDurationMs")
         return int(value) if value is not None else None
 
+    def scenario_version_constraints(self, scenario: dict[str, Any]) -> dict[str, str]:
+        constraints = scenario.get("sdkVersions")
+        if constraints is None:
+            return {}
+        if not isinstance(constraints, dict):
+            raise ValueError("sdkVersions must be an object keyed by adapter name")
+
+        if self.known_adapter_names is None:
+            self.known_adapter_names = set(discover_adapters())
+        unknown_adapters = set(constraints) - self.known_adapter_names
+        if unknown_adapters:
+            names = ", ".join(sorted(unknown_adapters))
+            raise ValueError(f"sdkVersions contains unknown adapter keys: {names}")
+
+        for adapter_name, expression in constraints.items():
+            if not isinstance(expression, str):
+                raise ValueError(f"sdkVersions.{adapter_name} must be a string")
+        return constraints
+
     def scenario_version_applies(
         self, scenario: dict[str, Any], adapter: AdapterConfig
     ) -> tuple[bool, str | None]:
-        constraints = scenario.get("sdkVersions")
-        if constraints is None:
-            return True, None
-        if not isinstance(constraints, dict):
-            raise ValueError("sdkVersions must be an object keyed by adapter name")
+        constraints = self.scenario_version_constraints(scenario)
 
         expression = constraints.get(adapter.name)
         if expression is None:
             return True, None
-        if not isinstance(expression, str):
-            raise ValueError(f"sdkVersions.{adapter.name} must be a string")
 
         if adapter.name not in self.sdk_versions:
             self.sdk_versions[adapter.name] = self.sdk_version_resolver(adapter.name)
@@ -489,6 +504,7 @@ class VectorRunner:
         is_challenge_id = generate_cmd is not None
 
         for scenario in vectors.get("scenarios", []):
+            self.scenario_version_constraints(scenario)
             name = scenario["name"]
             scenario_adapters = scenario.get("adapters")
             if scenario_adapters and adapter.name not in scenario_adapters:
@@ -499,6 +515,7 @@ class VectorRunner:
 
             applies, reason = self.scenario_version_applies(scenario, adapter)
             if not applies:
+                self.version_skips += 1
                 if self.verbose:
                     self.log(f"  {vector_name}::{name} SKIPPED ({reason})")
                 continue
@@ -696,6 +713,7 @@ class VectorRunner:
     ) -> bool:
         """Run all conformance tests."""
         adapters = discover_adapters()
+        self.known_adapter_names = set(adapters)
         if adapter_names is None:
             adapter_names = list(adapters.keys())
         
@@ -790,7 +808,7 @@ class VectorRunner:
                         for line in r.error.split("\n"):
                             self.log(f"    {line}")
 
-        if not self.results:
+        if not self.results and not self.version_skips:
             self._record_result(
                 vector_file="runner",
                 test_type=TestType.BUILD,
@@ -835,6 +853,7 @@ class VectorRunner:
             "num_checks": total,
             "passed": passed,
             "failed": failed,
+            "skipped": self.version_skips,
             "checks": [r.to_check() for r in self.results],
             "errors": errors,
         }

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -24,12 +24,14 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from deepdiff import DeepDiff
 
 from conformance_checks import make_check
 from harness import AdapterClient, AdapterConfig, build_adapter, discover_adapters
+from sdk_version import installed_version
+from version_constraints import matches_constraint
 
 
 SCRIPT_DIR = Path(__file__).parent
@@ -168,10 +170,17 @@ class TestResult:
 class VectorRunner:
     """Runs conformance tests against registered adapters."""
 
-    def __init__(self, verbose: bool = False, output_format: str = "text"):
+    def __init__(
+        self,
+        verbose: bool = False,
+        output_format: str = "text",
+        sdk_version_resolver: Callable[[str], str] | None = None,
+    ):
         self.verbose = verbose
         self.output_format = output_format
         self.results: list[TestResult] = []
+        self.sdk_version_resolver = sdk_version_resolver or installed_version
+        self.sdk_versions: dict[str, str] = {}
     
     def log(self, msg: str, end: str = "\n", flush: bool = False) -> None:
         """Print message only if output format is text."""
@@ -220,6 +229,29 @@ class VectorRunner:
             return int(per_adapter[adapter.name])
         value = scenario.get("maxDurationMs")
         return int(value) if value is not None else None
+
+    def scenario_version_applies(
+        self, scenario: dict[str, Any], adapter: AdapterConfig
+    ) -> tuple[bool, str | None]:
+        constraints = scenario.get("sdkVersions")
+        if constraints is None:
+            return True, None
+        if not isinstance(constraints, dict):
+            raise ValueError("sdkVersions must be an object keyed by adapter name")
+
+        expression = constraints.get(adapter.name)
+        if expression is None:
+            return True, None
+        if not isinstance(expression, str):
+            raise ValueError(f"sdkVersions.{adapter.name} must be a string")
+
+        if adapter.name not in self.sdk_versions:
+            self.sdk_versions[adapter.name] = self.sdk_version_resolver(adapter.name)
+        version = self.sdk_versions[adapter.name]
+        applies = matches_constraint(version, expression)
+        if applies:
+            return True, None
+        return False, f"{adapter.name}@{version} does not satisfy {expression}"
 
     def compare_duration(
         self, limit_ms: int | None, elapsed_ms: float
@@ -457,6 +489,7 @@ class VectorRunner:
         is_challenge_id = generate_cmd is not None
 
         for scenario in vectors.get("scenarios", []):
+            name = scenario["name"]
             scenario_adapters = scenario.get("adapters")
             if scenario_adapters and adapter.name not in scenario_adapters:
                 continue
@@ -464,7 +497,12 @@ class VectorRunner:
             if tag_filter and tag_filter not in scenario.get("tags", []):
                 continue
 
-            name = scenario["name"]
+            applies, reason = self.scenario_version_applies(scenario, adapter)
+            if not applies:
+                if self.verbose:
+                    self.log(f"  {vector_name}::{name} SKIPPED ({reason})")
+                continue
+
             description = scenario.get("description")
             tags = scenario.get("tags", [])
             tests = scenario.get("tests", {})

--- a/conformance/scripts/version_constraints.py
+++ b/conformance/scripts/version_constraints.py
@@ -1,0 +1,122 @@
+"""SemVer parsing and comparator constraints for conformance scenarios."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import total_ordering
+
+
+_SEMVER_TEXT = (
+    r"v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+)
+_SEMVER_RE = re.compile(
+    r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+_COMPARATOR_RE = re.compile(rf"(<=|>=|==|=|<|>)\s*({_SEMVER_TEXT})")
+
+
+@total_ordering
+@dataclass(frozen=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...] = ()
+
+    @classmethod
+    def parse(cls, value: str) -> SemVer:
+        match = _SEMVER_RE.fullmatch(value.strip())
+        if not match:
+            raise ValueError(f"Invalid SemVer version: {value!r}")
+
+        prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
+        if any(
+            identifier.isdigit()
+            and len(identifier) > 1
+            and identifier.startswith("0")
+            for identifier in prerelease
+        ):
+            raise ValueError(f"Invalid SemVer version: {value!r}")
+
+        return cls(
+            major=int(match.group(1)),
+            minor=int(match.group(2)),
+            patch=int(match.group(3)),
+            prerelease=prerelease,
+        )
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+
+        own_core = (self.major, self.minor, self.patch)
+        other_core = (other.major, other.minor, other.patch)
+        if own_core != other_core:
+            return own_core < other_core
+        if not self.prerelease:
+            return False
+        if not other.prerelease:
+            return True
+
+        for own_identifier, other_identifier in zip(self.prerelease, other.prerelease):
+            if own_identifier == other_identifier:
+                continue
+            own_numeric = own_identifier.isdigit()
+            other_numeric = other_identifier.isdigit()
+            if own_numeric and other_numeric:
+                return int(own_identifier) < int(other_identifier)
+            if own_numeric != other_numeric:
+                return own_numeric
+            return own_identifier < other_identifier
+        return len(self.prerelease) < len(other.prerelease)
+
+
+def _comparators(expression: str) -> list[tuple[str, SemVer]]:
+    if not isinstance(expression, str) or not expression.strip():
+        raise ValueError("SemVer constraint must be a non-empty string")
+
+    comparators: list[tuple[str, SemVer]] = []
+    position = 0
+    while position < len(expression):
+        separator = re.match(r"[\s,]*", expression[position:]).group(0)
+        if comparators and not separator:
+            raise ValueError(f"Invalid SemVer constraint: {expression!r}")
+        if not comparators and "," in separator:
+            raise ValueError(f"Invalid SemVer constraint: {expression!r}")
+        position += len(separator)
+        if position == len(expression):
+            if "," in separator:
+                raise ValueError(f"Invalid SemVer constraint: {expression!r}")
+            break
+
+        match = _COMPARATOR_RE.match(expression, position)
+        if not match:
+            raise ValueError(f"Invalid SemVer constraint: {expression!r}")
+        comparators.append((match.group(1), SemVer.parse(match.group(2))))
+        position = match.end()
+
+    if not comparators:
+        raise ValueError(f"Invalid SemVer constraint: {expression!r}")
+    return comparators
+
+
+def matches_constraint(version: str, expression: str) -> bool:
+    """Return whether a SemVer version satisfies every comparator."""
+    actual = SemVer.parse(version)
+    operations = {
+        "=": lambda expected: actual == expected,
+        "==": lambda expected: actual == expected,
+        "<": lambda expected: actual < expected,
+        "<=": lambda expected: actual <= expected,
+        ">": lambda expected: actual > expected,
+        ">=": lambda expected: actual >= expected,
+    }
+    return all(
+        operations[operator](expected)
+        for operator, expected in _comparators(expression)
+    )

--- a/conformance/scripts/version_constraints.py
+++ b/conformance/scripts/version_constraints.py
@@ -1,120 +1,21 @@
-"""SemVer parsing and comparator constraints for conformance scenarios."""
+"""SemVer constraints for conformance scenarios."""
 
-from __future__ import annotations
-
-import re
-from dataclasses import dataclass
-from functools import total_ordering
-
-
-_SEMVER_TEXT = (
-    r"v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
-    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
-    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
-)
-_SEMVER_RE = re.compile(
-    r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
-    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?"
-    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
-)
-_COMPARATOR_RE = re.compile(rf"(<=|>=|==|=|<|>)\s*({_SEMVER_TEXT})")
-
-
-@total_ordering
-@dataclass(frozen=True)
-class SemVer:
-    major: int
-    minor: int
-    patch: int
-    prerelease: tuple[str, ...] = ()
-
-    @classmethod
-    def parse(cls, value: str) -> SemVer:
-        match = _SEMVER_RE.fullmatch(value.strip())
-        if not match:
-            raise ValueError(f"Invalid SemVer version: {value!r}")
-
-        prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
-        if any(
-            identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0")
-            for identifier in prerelease
-        ):
-            raise ValueError(f"Invalid SemVer version: {value!r}")
-
-        return cls(
-            major=int(match.group(1)),
-            minor=int(match.group(2)),
-            patch=int(match.group(3)),
-            prerelease=prerelease,
-        )
-
-    def __lt__(self, other: object) -> bool:
-        if not isinstance(other, SemVer):
-            return NotImplemented
-
-        own_core = (self.major, self.minor, self.patch)
-        other_core = (other.major, other.minor, other.patch)
-        if own_core != other_core:
-            return own_core < other_core
-        if not self.prerelease:
-            return False
-        if not other.prerelease:
-            return True
-
-        for own_identifier, other_identifier in zip(self.prerelease, other.prerelease):
-            if own_identifier == other_identifier:
-                continue
-            own_numeric = own_identifier.isdigit()
-            other_numeric = other_identifier.isdigit()
-            if own_numeric and other_numeric:
-                return int(own_identifier) < int(other_identifier)
-            if own_numeric != other_numeric:
-                return own_numeric
-            return own_identifier < other_identifier
-        return len(self.prerelease) < len(other.prerelease)
-
-
-def _comparators(expression: str) -> list[tuple[str, SemVer]]:
-    if not isinstance(expression, str) or not expression.strip():
-        raise ValueError("SemVer constraint must be a non-empty string")
-
-    comparators: list[tuple[str, SemVer]] = []
-    position = 0
-    while position < len(expression):
-        separator = re.match(r"[\s,]*", expression[position:]).group(0)
-        if comparators and not separator:
-            raise ValueError(f"Invalid SemVer constraint: {expression!r}")
-        if not comparators and "," in separator:
-            raise ValueError(f"Invalid SemVer constraint: {expression!r}")
-        position += len(separator)
-        if position == len(expression):
-            if "," in separator:
-                raise ValueError(f"Invalid SemVer constraint: {expression!r}")
-            break
-
-        match = _COMPARATOR_RE.match(expression, position)
-        if not match:
-            raise ValueError(f"Invalid SemVer constraint: {expression!r}")
-        comparators.append((match.group(1), SemVer.parse(match.group(2))))
-        position = match.end()
-
-    if not comparators:
-        raise ValueError(f"Invalid SemVer constraint: {expression!r}")
-    return comparators
+from semantic_version import NpmSpec, Version
 
 
 def matches_constraint(version: str, expression: str) -> bool:
-    """Return whether a SemVer version satisfies every comparator."""
-    actual = SemVer.parse(version)
-    operations = {
-        "=": lambda expected: actual == expected,
-        "==": lambda expected: actual == expected,
-        "<": lambda expected: actual < expected,
-        "<=": lambda expected: actual <= expected,
-        ">": lambda expected: actual > expected,
-        ">=": lambda expected: actual >= expected,
-    }
-    return all(
-        operations[operator](expected)
-        for operator, expected in _comparators(expression)
-    )
+    """Return whether a version satisfies an npm-style SemVer constraint."""
+    if not isinstance(expression, str) or not expression.strip():
+        raise ValueError("SemVer constraint must be a non-empty string")
+
+    try:
+        actual = Version(version.removeprefix("v"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid SemVer version: {version!r}") from exc
+
+    try:
+        constraint = NpmSpec(expression)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid SemVer constraint: {expression!r}") from exc
+
+    return constraint.match(actual)

--- a/conformance/scripts/version_constraints.py
+++ b/conformance/scripts/version_constraints.py
@@ -36,9 +36,7 @@ class SemVer:
 
         prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
         if any(
-            identifier.isdigit()
-            and len(identifier) > 1
-            and identifier.startswith("0")
+            identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0")
             for identifier in prerelease
         ):
             raise ValueError(f"Invalid SemVer version: {value!r}")


### PR DESCRIPTION
## Motivation

Allow conformance rules to apply only to SDK releases that implement the required behavior without excluding an adapter permanently.

## Summary

- Add per-scenario `sdkVersions` constraints.
- Resolve and cache installed SDK versions during vector runs.
- Evaluate constraints with the `semantic-version` library.
- Document npm-style constraint syntax and cover filtering and version reporting.

## Key design considerations

- Use native npm-style SemVer ranges such as `<=1.2.3` and `>=1.0.0 <2.0.0`.
- Normalize the leading `v` used by Go module versions before library evaluation.
- Fail on invalid constraints or non-SemVer versions instead of silently skipping coverage.
