### PR TITLE
refactor: share stdlib JSON comparison

### DIFF
--- a/conformance/pyproject.toml
+++ b/conformance/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 description = "Cross-SDK MPP conformance runner"
 requires-python = ">=3.12"
 dependencies = [
-    "deepdiff>=8.6.1,<9",
     "jsonschema>=4.26.0,<5",
     "semantic-version>=2.10.0,<3",
 ]

--- a/conformance/scripts/comparison.py
+++ b/conformance/scripts/comparison.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from difflib import unified_diff
+from typing import Any
+
+
+def _normalized(value: Any, *, ignore_order: bool) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _normalized(item, ignore_order=ignore_order)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        items = [_normalized(item, ignore_order=ignore_order) for item in value]
+        if ignore_order:
+            items.sort(key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")))
+        return items
+    return value
+
+
+def json_diff(expected: Any, actual: Any, *, ignore_order: bool = False) -> str:
+    expected = _normalized(expected, ignore_order=ignore_order)
+    actual = _normalized(actual, ignore_order=ignore_order)
+    if expected == actual:
+        return ""
+
+    expected_lines = json.dumps(expected, indent=2, sort_keys=True, default=str).splitlines()
+    actual_lines = json.dumps(actual, indent=2, sort_keys=True, default=str).splitlines()
+    return "\n".join(
+        unified_diff(
+            expected_lines,
+            actual_lines,
+            fromfile="expected",
+            tofile="actual",
+            lineterm="",
+        )
+    )
+
+
+def format_json_mismatch(
+    expected: Any,
+    actual: Any,
+    label: str = "result",
+    *,
+    ignore_order: bool = False,
+) -> str:
+    diff = json_diff(expected, actual, ignore_order=ignore_order)
+    return f"{label} mismatch:\n{diff}" if diff else ""

--- a/conformance/scripts/flow_runner.py
+++ b/conformance/scripts/flow_runner.py
@@ -15,8 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from deepdiff import DeepDiff
-
+from comparison import json_diff
 from conformance_checks import make_check
 from harness import (
     AdapterClient,
@@ -52,13 +51,6 @@ def normalize_result(entry: dict[str, Any]) -> dict[str, Any]:
         challenge.pop("expires", None)
     normalized.pop("problem_details", None)
     return normalized
-
-
-def compute_diff(expected: Any, actual: Any) -> str:
-    diff = DeepDiff(expected, actual, ignore_order=True, verbose_level=2)
-    if not diff:
-        return ""
-    return json.dumps(diff, indent=2, default=str)
 
 
 @dataclass
@@ -650,7 +642,7 @@ def compare_results(
             results.append(RunResult(adapter=adapter, name=str(name), passed=True))
             unmatched.discard(name)
             continue
-        diff = compute_diff(normalize_result(golden), normalize_result(entry))
+        diff = json_diff(normalize_result(golden), normalize_result(entry), ignore_order=True)
         results.append(RunResult(adapter=adapter, name=str(name), passed=diff == "", error=diff or None))
         unmatched.discard(name)
     for name in sorted(unmatched):

--- a/conformance/scripts/server_verify_runner.py
+++ b/conformance/scripts/server_verify_runner.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from comparison import format_json_mismatch
 from harness import AdapterConfig, AdapterClient, build_adapter, discover_adapters
 
 
@@ -32,16 +33,6 @@ def load_cases() -> list[dict[str, Any]]:
     if not isinstance(cases, list):
         raise ValueError("Invalid server verification cases payload")
     return cases
-
-
-def compute_diff(expected: Any, actual: Any) -> str:
-    if expected == actual:
-        return ""
-    return "\n".join([
-        "result mismatch:",
-        f"  expected: {json.dumps(expected, sort_keys=True, indent=2)}",
-        f"  actual:   {json.dumps(actual, sort_keys=True, indent=2)}",
-    ])
 
 
 def selected_adapters(name: str, adapters: dict[str, AdapterConfig]) -> list[str]:
@@ -83,7 +74,7 @@ def run_adapter(adapter: AdapterConfig, cases: list[dict[str, Any]]) -> list[Run
 
         expected = case.get("expected")
         actual = response.get("value")
-        diff = compute_diff(expected, actual)
+        diff = format_json_mismatch(expected, actual)
         results.append(RunResult(adapter=adapter.name, name=name, passed=diff == "", error=diff or None))
     return results
 

--- a/conformance/scripts/test_comparison.py
+++ b/conformance/scripts/test_comparison.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import unittest
+
+from comparison import format_json_mismatch, json_diff
+
+
+class JsonComparisonTests(unittest.TestCase):
+    def test_equal_values_have_no_diff(self) -> None:
+        self.assertEqual(json_diff({"value": [1, 2]}, {"value": [1, 2]}), "")
+
+    def test_array_order_can_be_ignored_recursively(self) -> None:
+        expected = {"items": [{"id": 1}, {"id": 2}]}
+        actual = {"items": [{"id": 2}, {"id": 1}]}
+
+        self.assertEqual(json_diff(expected, actual, ignore_order=True), "")
+        self.assertNotEqual(json_diff(expected, actual), "")
+
+    def test_mismatch_is_a_unified_json_diff(self) -> None:
+        mismatch = format_json_mismatch({"status": "success"}, {"status": "failed"})
+
+        self.assertIn("result mismatch:", mismatch)
+        self.assertIn("--- expected", mismatch)
+        self.assertIn("+++ actual", mismatch)
+        self.assertIn('-  "status": "success"', mismatch)
+        self.assertIn('+  "status": "failed"', mismatch)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -26,8 +26,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable
 
-from deepdiff import DeepDiff
-
+from comparison import format_json_mismatch
 from conformance_checks import make_check
 from harness import AdapterClient, AdapterConfig, build_adapter, discover_adapters, load_vector
 from sdk_version import installed_version
@@ -35,16 +34,6 @@ from version_constraints import matches_constraint
 
 
 SCRIPT_DIR = Path(__file__).parent
-
-
-class DiffType(str, Enum):
-    """Enum for DeepDiff dictionary keys."""
-    VALUES_CHANGED = "values_changed"
-    DICTIONARY_ITEM_ADDED = "dictionary_item_added"
-    DICTIONARY_ITEM_REMOVED = "dictionary_item_removed"
-    TYPE_CHANGES = "type_changes"
-    ITERABLE_ITEM_ADDED = "iterable_item_added"
-    ITERABLE_ITEM_REMOVED = "iterable_item_removed"
 
 
 class TestType(str, Enum):
@@ -62,49 +51,9 @@ def base64url_decode(s: str) -> bytes:
     return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
 
-def compute_diff(expected: Any, actual: Any) -> str:
-    """Compute a human-readable diff between expected and actual values."""
-    diff = DeepDiff(expected, actual, ignore_order=True, verbose_level=2)
-    if not diff:
-        return ""
-    lines = []
-    if DiffType.VALUES_CHANGED in diff:
-        for path, change in diff[DiffType.VALUES_CHANGED].items():
-            lines.append(f"  {path}: {change['old_value']!r} → {change['new_value']!r}")
-    if DiffType.DICTIONARY_ITEM_ADDED in diff:
-        for path in diff[DiffType.DICTIONARY_ITEM_ADDED]:
-            value = diff[DiffType.DICTIONARY_ITEM_ADDED][path]
-            lines.append(f"  + {path}: {value!r}")
-    if DiffType.DICTIONARY_ITEM_REMOVED in diff:
-        for path in diff[DiffType.DICTIONARY_ITEM_REMOVED]:
-            value = diff[DiffType.DICTIONARY_ITEM_REMOVED][path]
-            lines.append(f"  - {path}: {value!r}")
-    if DiffType.TYPE_CHANGES in diff:
-        for path, change in diff[DiffType.TYPE_CHANGES].items():
-            lines.append(f"  {path}: type {change['old_type'].__name__} → {change['new_type'].__name__}")
-            lines.append(f"    {change['old_value']!r} → {change['new_value']!r}")
-    if DiffType.ITERABLE_ITEM_ADDED in diff:
-        for path in diff[DiffType.ITERABLE_ITEM_ADDED]:
-            lines.append(f"  + {path}: {diff[DiffType.ITERABLE_ITEM_ADDED][path]!r}")
-    if DiffType.ITERABLE_ITEM_REMOVED in diff:
-        for path in diff[DiffType.ITERABLE_ITEM_REMOVED]:
-            lines.append(f"  - {path}: {diff[DiffType.ITERABLE_ITEM_REMOVED][path]!r}")
-    return "\n".join(lines)
-
-
 def format_mismatch_error(expected: Any, actual: Any, label: str = "result") -> str:
-    """Format a mismatch error with both full shapes and diff."""
-    diff_str = compute_diff(expected, actual)
-    error_parts = [
-        f"{label} mismatch:",
-        f"  expected: {json.dumps(expected, sort_keys=True, indent=2)}",
-        f"  actual:   {json.dumps(actual, sort_keys=True, indent=2)}",
-    ]
-    if diff_str:
-        error_parts.append(f"  diff:")
-        for line in diff_str.split("\n"):
-            error_parts.append(f"  {line}")
-    return "\n".join(error_parts)
+    """Format a mismatch as a unified JSON diff."""
+    return format_json_mismatch(expected, actual, label)
 
 
 CONFORMANCE_DIR = SCRIPT_DIR.parent

--- a/conformance/uv.lock
+++ b/conformance/uv.lock
@@ -12,18 +12,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deepdiff"
-version = "8.6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "orderly-set" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/89/50/767448e792d41bfb6094ee317a355c1cb221dca24b2e178e2203bbea2a77/deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e", size = 634860, upload-time = "2026-03-18T17:16:33.785Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/5f/c52bd1255db763d0cdcb7084d2e90c42119cb229302c56bdf1d0aa78abd2/deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4", size = 91979, upload-time = "2026-03-18T17:16:32.171Z" },
-]
-
-[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -55,25 +43,14 @@ name = "mpp-conformance-runner"
 version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
-    { name = "deepdiff" },
     { name = "jsonschema" },
     { name = "semantic-version" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "deepdiff", specifier = ">=8.6.1,<9" },
     { name = "jsonschema", specifier = ">=4.26.0,<5" },
     { name = "semantic-version", specifier = ">=2.10.0,<3" },
-]
-
-[[package]]
-name = "orderly-set"
-version = "5.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/88/39c83c35d5e97cc203e9e77a4f93bf87ec89cf6a22ac4818fdcc65d66584/orderly_set-5.5.0.tar.gz", hash = "sha256:e87185c8e4d8afa64e7f8160ee2c542a475b738bc891dc3f58102e654125e6ce", size = 27414, upload-time = "2025-07-10T20:10:55.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl", hash = "sha256:46f0b801948e98f427b412fcabb831677194c05c3b699b80de260374baa0b1e7", size = 13068, upload-time = "2025-07-10T20:10:54.377Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

Remove duplicate result comparison implementations and an avoidable runner dependency.

## Summary

- add one stdlib unified JSON diff helper
- share comparison across vector, flow, and server-verification runners
- remove DeepDiff and its transitive dependency

## Key design considerations

- flow comparisons retain recursive order-insensitive array semantics
- vector and server comparisons remain order-sensitive
- failure output uses stable, sorted JSON diffs