### PR TITLE
ci: enforce conformance static checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,5 +45,8 @@ jobs:
       - name: Install runner dependencies
         run: uv sync --locked
 
+      - name: Run Python static checks
+        run: make check-python
+
       - name: Run script tests
         run: uv run --locked python -m unittest discover -s scripts -p "test_*.py"

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -123,6 +123,9 @@ jobs:
       - name: Install adapter dependencies
         run: make ${{ matrix.install-target }}
 
+      - name: Run adapter static checks
+        run: make check-${{ matrix.adapter }}
+
       - name: Run vector conformance
         env:
           ADAPTER: ${{ matrix.adapter }}

--- a/.github/workflows/sdk-conformance.yml
+++ b/.github/workflows/sdk-conformance.yml
@@ -120,6 +120,11 @@ jobs:
         env:
           ADAPTER: ${{ steps.resolve.outputs.adapter }}
 
+      - name: Run adapter static checks
+        run: make check-$ADAPTER
+        env:
+          ADAPTER: ${{ steps.resolve.outputs.adapter }}
+
       - name: Run vector conformance
         run: uv run --locked python scripts/vector_runner.py --adapter "$ADAPTER"
         env:

--- a/conformance/Makefile
+++ b/conformance/Makefile
@@ -1,7 +1,7 @@
 # Conformance Testing Makefile
 # Cross-SDK protocol compatibility testing for MPP implementations
 
-.PHONY: all update-locks update-java install install-runner install-java use-local-sdk test test-all test-sdk test-typescript test-rust test-python test-go test-ruby test-java test-json flow flow-sdk flow-typescript flow-rust flow-python flow-go flow-ruby flow-java server-verify server-verify-sdk server-verify-go update-flow-golden clean help
+.PHONY: all update-locks update-java install install-runner install-java use-local-sdk check check-typescript check-rust check-python check-go check-ruby check-java test test-all test-sdk test-typescript test-rust test-python test-go test-ruby test-java test-json flow flow-sdk flow-typescript flow-rust flow-python flow-go flow-ruby flow-java server-verify server-verify-sdk server-verify-go update-flow-golden clean help
 
 RUBY ?= ruby
 BUNDLE ?= bundle
@@ -80,6 +80,32 @@ install-ruby:
 install-java:
 	@echo "→ Building Java adapter..."
 	cd adapters/java && ./gradlew --no-daemon installDist
+
+#------------------------------------------------------------------------------
+# Static checks
+#------------------------------------------------------------------------------
+
+check: check-python check-typescript check-rust check-go check-ruby check-java
+
+check-python:
+	$(RUNNER_PYTHON) -m ruff check scripts adapters/python/adapter.py adapters/ruby/run_adapter.py
+
+check-typescript:
+	npm run typecheck
+
+check-rust:
+	cd adapters/rust && cargo fmt --check
+	cd adapters/rust && cargo clippy --locked --all-targets -- -D warnings
+
+check-go:
+	@test -z "$$(cd adapters/go && gofmt -l .)" || (cd adapters/go && gofmt -d .; exit 1)
+	cd adapters/go && go vet ./...
+
+check-ruby:
+	cd adapters/ruby && $(RUBY) -c adapter.rb
+
+check-java:
+	cd adapters/java && ./gradlew --no-daemon check
 
 #------------------------------------------------------------------------------
 # Testing
@@ -223,6 +249,8 @@ help:
 	@echo "  install          Install all adapter dependencies"
 	@echo "  install-runner   Install shared runner dependencies only"
 	@echo "  use-local-sdk    Point one adapter at SDK_PATH, e.g. ADAPTER=rust SDK_PATH=../mpp-rs"
+	@echo "  check            Run static checks for the runner and all adapters"
+	@echo "  check-<adapter>  Run static checks for one adapter"
 	@echo "  test             Run conformance tests for all adapters"
 	@echo "  test-sdk         Run vector tests for ADAPTER"
 	@echo "  flow             Run flow conformance tests"

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -14,6 +14,7 @@ Or step by step:
 
 ```bash
 make install      # install the pinned TS/Rust/Python/Go/Ruby/Java releases
+make check        # run static checks for the runner and every adapter
 make test         # run SDK adapters against all vectors
 make flow         # run the end-to-end flow suite against golden results
 make server-verify # run SDK server verification ABI tests

--- a/conformance/adapters/python/adapter.py
+++ b/conformance/adapters/python/adapter.py
@@ -14,7 +14,6 @@ from mpp import (
     ChallengeEcho,
     Credential,
     Receipt,
-    generate_challenge_id,
     parse_www_authenticate,
     parse_authorization,
     format_www_authenticate,
@@ -352,7 +351,7 @@ def main():
             print(json.dumps(success(result)))
         elif command == "format-receipt":
             data = json.loads(input_data)
-            from datetime import datetime, UTC
+            from datetime import datetime
 
             ts_str = data.get("timestamp", "")
             ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))

--- a/conformance/adapters/rust/src/main.rs
+++ b/conformance/adapters/rust/src/main.rs
@@ -559,7 +559,7 @@ fn generate_conformance_challenge_id(params: ChallengeIdParams<'_>) -> Result<St
     const MINIMUM_SECRET_KEY_BYTES: usize = 32;
     type HmacSha256 = Hmac<Sha256>;
 
-    if params.secret_key.as_bytes().len() < MINIMUM_SECRET_KEY_BYTES {
+    if params.secret_key.len() < MINIMUM_SECRET_KEY_BYTES {
         return Err(format!(
             "secretKey must be at least {} bytes",
             MINIMUM_SECRET_KEY_BYTES

--- a/conformance/flows/compliance-server.ts
+++ b/conformance/flows/compliance-server.ts
@@ -74,7 +74,7 @@ if (!flowPath) {
   process.exit(1)
 }
 
-const flowFile = await import(pathToFileURL(flowPath).href, { assert: { type: 'json' } }).catch(
+const flowFile = await import(pathToFileURL(flowPath).href, { with: { type: 'json' } }).catch(
   (err) => {
     console.error('Failed to load flow cases:', err)
     process.exit(1)
@@ -333,7 +333,13 @@ const handler: http.RequestListener = async (req, res) => {
     res.end(JSON.stringify({ ok: false, name: flowCase.name, authorization_observed: true }))
     return
   }
-  if (!req.headers.authorization) acceptPaymentByPath.set(url.pathname, req.headers['accept-payment'] ?? null)
+  if (!req.headers.authorization) {
+    const acceptPayment = req.headers['accept-payment']
+    acceptPaymentByPath.set(
+      url.pathname,
+      Array.isArray(acceptPayment) ? acceptPayment.join(', ') : (acceptPayment ?? null),
+    )
+  }
   if (flowCase.concurrent_replay && req.headers.authorization) {
     const authorization = `${req.headers['x-flow-client'] ?? 'unknown'}:${req.headers.authorization}`
     if (seenAuthorization.has(authorization)) {

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "test:golden": "tsx golden/adapter.ts",
+    "typecheck": "tsc --noEmit",
     "test:all": "uv run --locked python scripts/vector_runner.py",
     "flow": "uv run --locked python scripts/flow_runner.py",
     "test:go": "uv run --locked python scripts/vector_runner.py --adapter go",

--- a/conformance/pyproject.toml
+++ b/conformance/pyproject.toml
@@ -9,5 +9,8 @@ dependencies = [
     "semantic-version>=2.10.0,<3",
 ]
 
+[dependency-groups]
+dev = ["ruff==0.15.0"]
+
 [tool.uv]
 package = false

--- a/conformance/pyproject.toml
+++ b/conformance/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.0.1"
 description = "Cross-SDK MPP conformance runner"
 requires-python = ">=3.12"
 dependencies = [
-    "deepdiff>=8.6.1,<9",
     "jsonschema>=4.26.0,<5",
     "rfc3339-validator>=0.1.4,<1",
     "semantic-version>=2.10.0,<3",

--- a/conformance/scripts/comparison.py
+++ b/conformance/scripts/comparison.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from difflib import unified_diff
+from typing import Any
+
+
+def _normalized(value: Any, *, ignore_order: bool) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _normalized(item, ignore_order=ignore_order)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        items = [_normalized(item, ignore_order=ignore_order) for item in value]
+        if ignore_order:
+            items.sort(key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")))
+        return items
+    return value
+
+
+def json_diff(expected: Any, actual: Any, *, ignore_order: bool = False) -> str:
+    expected = _normalized(expected, ignore_order=ignore_order)
+    actual = _normalized(actual, ignore_order=ignore_order)
+    if expected == actual:
+        return ""
+
+    expected_lines = json.dumps(expected, indent=2, sort_keys=True, default=str).splitlines()
+    actual_lines = json.dumps(actual, indent=2, sort_keys=True, default=str).splitlines()
+    return "\n".join(
+        unified_diff(
+            expected_lines,
+            actual_lines,
+            fromfile="expected",
+            tofile="actual",
+            lineterm="",
+        )
+    )
+
+
+def format_json_mismatch(
+    expected: Any,
+    actual: Any,
+    label: str = "result",
+    *,
+    ignore_order: bool = False,
+) -> str:
+    diff = json_diff(expected, actual, ignore_order=ignore_order)
+    return f"{label} mismatch:\n{diff}" if diff else ""

--- a/conformance/scripts/flow_runner.py
+++ b/conformance/scripts/flow_runner.py
@@ -15,8 +15,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from deepdiff import DeepDiff
-
+from comparison import json_diff
 from conformance_checks import make_check
 from harness import (
     AdapterClient,
@@ -53,13 +52,6 @@ def normalize_result(entry: dict[str, Any]) -> dict[str, Any]:
         challenge.pop("expires", None)
     normalized.pop("problem_details", None)
     return normalized
-
-
-def compute_diff(expected: Any, actual: Any) -> str:
-    diff = DeepDiff(expected, actual, ignore_order=True, verbose_level=2)
-    if not diff:
-        return ""
-    return json.dumps(diff, indent=2, default=str)
 
 
 @dataclass
@@ -655,7 +647,7 @@ def compare_results(
             results.append(RunResult(adapter=adapter, name=str(name), passed=True))
             unmatched.discard(name)
             continue
-        diff = compute_diff(normalize_result(golden), normalize_result(entry))
+        diff = json_diff(normalize_result(golden), normalize_result(entry), ignore_order=True)
         results.append(RunResult(adapter=adapter, name=str(name), passed=diff == "", error=diff or None))
         unmatched.discard(name)
     for name in sorted(unmatched):

--- a/conformance/scripts/server_verify_runner.py
+++ b/conformance/scripts/server_verify_runner.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from comparison import format_json_mismatch
 from harness import AdapterConfig, AdapterClient, build_adapter, discover_adapters
 
 
@@ -32,16 +33,6 @@ def load_cases() -> list[dict[str, Any]]:
     if not isinstance(cases, list):
         raise ValueError("Invalid server verification cases payload")
     return cases
-
-
-def compute_diff(expected: Any, actual: Any) -> str:
-    if expected == actual:
-        return ""
-    return "\n".join([
-        "result mismatch:",
-        f"  expected: {json.dumps(expected, sort_keys=True, indent=2)}",
-        f"  actual:   {json.dumps(actual, sort_keys=True, indent=2)}",
-    ])
 
 
 def selected_adapters(name: str, adapters: dict[str, AdapterConfig]) -> list[str]:
@@ -83,7 +74,7 @@ def run_adapter(adapter: AdapterConfig, cases: list[dict[str, Any]]) -> list[Run
 
         expected = case.get("expected")
         actual = response.get("value")
-        diff = compute_diff(expected, actual)
+        diff = format_json_mismatch(expected, actual)
         results.append(RunResult(adapter=adapter.name, name=name, passed=diff == "", error=diff or None))
     return results
 

--- a/conformance/scripts/test_comparison.py
+++ b/conformance/scripts/test_comparison.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import unittest
+
+from comparison import format_json_mismatch, json_diff
+
+
+class JsonComparisonTests(unittest.TestCase):
+    def test_equal_values_have_no_diff(self) -> None:
+        self.assertEqual(json_diff({"value": [1, 2]}, {"value": [1, 2]}), "")
+
+    def test_array_order_can_be_ignored_recursively(self) -> None:
+        expected = {"items": [{"id": 1}, {"id": 2}]}
+        actual = {"items": [{"id": 2}, {"id": 1}]}
+
+        self.assertEqual(json_diff(expected, actual, ignore_order=True), "")
+        self.assertNotEqual(json_diff(expected, actual), "")
+
+    def test_mismatch_is_a_unified_json_diff(self) -> None:
+        mismatch = format_json_mismatch({"status": "success"}, {"status": "failed"})
+
+        self.assertIn("result mismatch:", mismatch)
+        self.assertIn("--- expected", mismatch)
+        self.assertIn("+++ actual", mismatch)
+        self.assertIn('-  "status": "success"', mismatch)
+        self.assertIn('+  "status": "failed"', mismatch)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -26,8 +26,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable
 
-from deepdiff import DeepDiff
-
+from comparison import format_json_mismatch
 from conformance_checks import make_check
 from harness import AdapterClient, AdapterConfig, build_adapter, discover_adapters, load_vector
 from sdk_version import installed_version
@@ -35,16 +34,6 @@ from version_constraints import matches_constraint
 
 
 SCRIPT_DIR = Path(__file__).parent
-
-
-class DiffType(str, Enum):
-    """Enum for DeepDiff dictionary keys."""
-    VALUES_CHANGED = "values_changed"
-    DICTIONARY_ITEM_ADDED = "dictionary_item_added"
-    DICTIONARY_ITEM_REMOVED = "dictionary_item_removed"
-    TYPE_CHANGES = "type_changes"
-    ITERABLE_ITEM_ADDED = "iterable_item_added"
-    ITERABLE_ITEM_REMOVED = "iterable_item_removed"
 
 
 class TestType(str, Enum):
@@ -62,49 +51,9 @@ def base64url_decode(s: str) -> bytes:
     return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
 
 
-def compute_diff(expected: Any, actual: Any) -> str:
-    """Compute a human-readable diff between expected and actual values."""
-    diff = DeepDiff(expected, actual, ignore_order=True, verbose_level=2)
-    if not diff:
-        return ""
-    lines = []
-    if DiffType.VALUES_CHANGED in diff:
-        for path, change in diff[DiffType.VALUES_CHANGED].items():
-            lines.append(f"  {path}: {change['old_value']!r} → {change['new_value']!r}")
-    if DiffType.DICTIONARY_ITEM_ADDED in diff:
-        for path in diff[DiffType.DICTIONARY_ITEM_ADDED]:
-            value = diff[DiffType.DICTIONARY_ITEM_ADDED][path]
-            lines.append(f"  + {path}: {value!r}")
-    if DiffType.DICTIONARY_ITEM_REMOVED in diff:
-        for path in diff[DiffType.DICTIONARY_ITEM_REMOVED]:
-            value = diff[DiffType.DICTIONARY_ITEM_REMOVED][path]
-            lines.append(f"  - {path}: {value!r}")
-    if DiffType.TYPE_CHANGES in diff:
-        for path, change in diff[DiffType.TYPE_CHANGES].items():
-            lines.append(f"  {path}: type {change['old_type'].__name__} → {change['new_type'].__name__}")
-            lines.append(f"    {change['old_value']!r} → {change['new_value']!r}")
-    if DiffType.ITERABLE_ITEM_ADDED in diff:
-        for path in diff[DiffType.ITERABLE_ITEM_ADDED]:
-            lines.append(f"  + {path}: {diff[DiffType.ITERABLE_ITEM_ADDED][path]!r}")
-    if DiffType.ITERABLE_ITEM_REMOVED in diff:
-        for path in diff[DiffType.ITERABLE_ITEM_REMOVED]:
-            lines.append(f"  - {path}: {diff[DiffType.ITERABLE_ITEM_REMOVED][path]!r}")
-    return "\n".join(lines)
-
-
 def format_mismatch_error(expected: Any, actual: Any, label: str = "result") -> str:
-    """Format a mismatch error with both full shapes and diff."""
-    diff_str = compute_diff(expected, actual)
-    error_parts = [
-        f"{label} mismatch:",
-        f"  expected: {json.dumps(expected, sort_keys=True, indent=2)}",
-        f"  actual:   {json.dumps(actual, sort_keys=True, indent=2)}",
-    ]
-    if diff_str:
-        error_parts.append(f"  diff:")
-        for line in diff_str.split("\n"):
-            error_parts.append(f"  {line}")
-    return "\n".join(error_parts)
+    """Format a mismatch as a unified JSON diff."""
+    return format_json_mismatch(expected, actual, label)
 
 
 CONFORMANCE_DIR = SCRIPT_DIR.parent

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -711,10 +711,10 @@ class VectorRunner:
 
             # Build if needed
             if adapter.build_command:
-                self.log(f"  building...", end="", flush=True)
+                self.log("  building...", end="", flush=True)
                 build_error = build_adapter(adapter)
                 if build_error:
-                    self.log(f" FAILED")
+                    self.log(" FAILED")
                     self._record_result(
                         vector_file="adapter",
                         test_type=TestType.BUILD,
@@ -727,11 +727,11 @@ class VectorRunner:
                         error=build_error,
                     )
                     continue
-                self.log(f" ok")
+                self.log(" ok")
             else:
                 build_error = build_adapter(adapter)
                 if build_error:
-                    self.log(f"  build FAILED")
+                    self.log("  build FAILED")
                     self._record_result(
                         vector_file="adapter",
                         test_type=TestType.BUILD,

--- a/conformance/tsconfig.json
+++ b/conformance/tsconfig.json
@@ -9,7 +9,8 @@
     "outDir": "dist",
     "rootDir": ".",
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": ["golden/**/*.ts", "scripts/**/*.ts", "flows/**/*.ts"],
   "exclude": ["node_modules", "dist"]

--- a/conformance/uv.lock
+++ b/conformance/uv.lock
@@ -12,18 +12,6 @@ wheels = [
 ]
 
 [[package]]
-name = "deepdiff"
-version = "8.6.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "orderly-set" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/89/50/767448e792d41bfb6094ee317a355c1cb221dca24b2e178e2203bbea2a77/deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e", size = 634860, upload-time = "2026-03-18T17:16:33.785Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/5f/c52bd1255db763d0cdcb7084d2e90c42119cb229302c56bdf1d0aa78abd2/deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4", size = 91979, upload-time = "2026-03-18T17:16:32.171Z" },
-]
-
-[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -55,7 +43,6 @@ name = "mpp-conformance-runner"
 version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
-    { name = "deepdiff" },
     { name = "jsonschema" },
     { name = "rfc3339-validator" },
     { name = "semantic-version" },
@@ -63,19 +50,9 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "deepdiff", specifier = ">=8.6.1,<9" },
     { name = "jsonschema", specifier = ">=4.26.0,<5" },
     { name = "rfc3339-validator", specifier = ">=0.1.4,<1" },
     { name = "semantic-version", specifier = ">=2.10.0,<3" },
-]
-
-[[package]]
-name = "orderly-set"
-version = "5.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/88/39c83c35d5e97cc203e9e77a4f93bf87ec89cf6a22ac4818fdcc65d66584/orderly_set-5.5.0.tar.gz", hash = "sha256:e87185c8e4d8afa64e7f8160ee2c542a475b738bc891dc3f58102e654125e6ce", size = 27414, upload-time = "2025-07-10T20:10:55.885Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl", hash = "sha256:46f0b801948e98f427b412fcabb831677194c05c3b699b80de260374baa0b1e7", size = 13068, upload-time = "2025-07-10T20:10:54.377Z" },
 ]
 
 [[package]]

--- a/conformance/uv.lock
+++ b/conformance/uv.lock
@@ -48,12 +48,20 @@ dependencies = [
     { name = "semantic-version" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "jsonschema", specifier = ">=4.26.0,<5" },
     { name = "rfc3339-validator", specifier = ">=0.1.4,<1" },
     { name = "semantic-version", specifier = ">=2.10.0,<3" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = "==0.15.0" }]
 
 [[package]]
 name = "referencing"
@@ -175,6 +183,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
     { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
     { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Motivation

Catch cross-language drift before it reaches conformance execution.

## Summary

- add TypeScript typechecking and Python Ruff checks
- enforce Rust formatting and Clippy plus Go formatting and vetting
- add Ruby syntax and Java Gradle checks
- run adapter-specific checks in conformance workflows

## Key design considerations

- checks are exposed through consistent Make targets
- existing adapter builds remain unchanged
- fixes are limited to issues surfaced by the new checks