### PR TITLE
docs: define mppx as conformance oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ mpp-tools/
 
 ## Conformance Suite
 
-The conformance suite ensures every SDK produces identical protocol outputs for the same inputs. No SDK is privileged: checked-in JSON vectors are the source of truth, and each SDK is exercised through a thin CLI adapter with a shared request/response contract.
+The conformance suite ensures every SDK produces identical protocol outputs for the same inputs. The pinned `mppx` release is the reference implementation: it produces canonical flow results and resolves behavior that the protocol specification leaves ambiguous. Checked-in JSON vectors remain the normative fixtures for their explicit inputs and expected outputs. Each SDK is exercised through a thin CLI adapter with a shared request/response contract.
 
 ```text
 vectors/*.json -> vector_runner.py -> adapter -> pass/fail

--- a/conformance/HARNESS_SPEC.md
+++ b/conformance/HARNESS_SPEC.md
@@ -18,6 +18,18 @@ The normative contract lives in JSON Schema:
 The operation list lives in [`operations.json`](./operations.json). Examples
 live in [`examples/`](./examples/).
 
+## Reference Implementation
+
+The pinned TypeScript `mppx` package is the executable reference implementation.
+It defines canonical serialization and flow behavior where the protocol
+specification permits multiple interpretations. Hand-authored vectors remain
+normative for their explicit inputs and expected outputs.
+
+Only the TypeScript adapter may regenerate `flows/golden-results.json`. Golden
+changes must be reviewed and committed with the fixture or pinned `mppx` change
+that caused them. Other adapters are always compared with the checked-in golden
+results and never update them.
+
 ## Simplification Plan
 
 1. Add one adapter manifest per language.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -21,7 +21,7 @@ make server-verify # run SDK server verification ABI tests
 
 ## How It Works
 
-Test vectors are hand-authored JSON files in `vectors/`. No SDK is privileged — the vectors are the single source of truth.
+Test vectors are hand-authored JSON files in `vectors/`. Their explicit inputs and expected outputs are normative. The pinned TypeScript `mppx` package is the reference implementation for canonical serialization, flow behavior, and cases where the protocol specification permits multiple interpretations.
 
 Each SDK has a thin **adapter** CLI that wraps its library and exposes a uniform interface. A Python test runner invokes every adapter against every vector and compares outputs.
 
@@ -29,7 +29,7 @@ Each SDK has a thin **adapter** CLI that wraps its library and exposes a uniform
 vectors/*.json ──► vector_runner.py ──► adapter (Rust/Python/Go/Ruby/Java) ──► pass/fail
 ```
 
-The TypeScript adapter remains the golden implementation for fixture maintenance and can be run explicitly with `make test-typescript`. Default vector runs skip it because the vector JSON files are the checked golden source of truth.
+The TypeScript adapter is the reference implementation for fixture maintenance and can be run explicitly with `make test-typescript`. Default vector runs skip it because checked-in vector expectations do not need to be regenerated on every run.
 
 See [`HARNESS_SPEC.md`](./HARNESS_SPEC.md) for the schema-backed adapter ABI, manifest format, operation registry, migration plan, and language skeletons.
 
@@ -94,7 +94,7 @@ make flow
 
 The Python flow runner owns the HTTP state machine. It calls each adapter's existing parse/format commands to parse the challenge, format the credential, and parse the receipt. This keeps flow tests focused on protocol compatibility rather than each SDK's HTTP transport implementation.
 
-Flow assertions compare adapter results against `flows/golden-results.json`, generated with the pinned TypeScript `mppx` package. Regenerate it with `make update-flow-golden` when the flow fixtures intentionally change.
+Flow assertions compare adapter results against `flows/golden-results.json`, generated exclusively with the pinned TypeScript `mppx` package. Regenerate it with `make update-flow-golden` only when the flow fixtures or pinned `mppx` behavior intentionally change, and commit the golden diff with that change.
 
 ## Server Verification Tests
 


### PR DESCRIPTION
## Motivation

Make the conformance authority explicit and remove contradictory guidance about golden behavior.

## Summary

- document pinned `mppx` as the executable reference implementation
- define checked-in vector expectations as normative fixtures
- define ownership and review policy for flow golden updates

## Key design considerations

- only the TypeScript adapter may regenerate flow goldens
- ambiguous protocol behavior follows the pinned `mppx` release