### PR TITLE
fix(runner): exit 1 when all scenarios are version-skipped

### DIFF
--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -282,7 +282,7 @@ class VectorRunnerJsonArtifactTest(unittest.TestCase):
         failing = [check for check in output["checks"] if check["status"] == "FAILURE"]
         self.assertTrue(any("vector-file-error" in check["id"] for check in failing))
 
-    def test_all_version_skipped_selection_passes(self) -> None:
+    def test_all_version_skipped_selection_fails(self) -> None:
         import vector_runner as vector_runner_module
 
         fake_adapter = AdapterConfig(name="fake", command=["true"], capabilities=[])
@@ -323,11 +323,14 @@ class VectorRunnerJsonArtifactTest(unittest.TestCase):
                 vector_runner_module.discover_vector_files = original_discover_vectors
                 vector_runner_module.discover_adapters = original_discover_adapters
 
-        self.assertTrue(success)
+        self.assertFalse(success)
         output = json.loads(stdout.getvalue())
-        self.assertEqual(output["status"], "pass")
-        self.assertEqual(output["num_checks"], 0)
+        self.assertEqual(output["status"], "fail")
+        self.assertEqual(output["num_checks"], 1)
         self.assertEqual(output["skipped"], 1)
+        failing = [c for c in output["checks"] if c["status"] == "FAILURE"]
+        self.assertEqual(len(failing), 1)
+        self.assertIn("version-skipped", failing[0]["error"])
 
 
 if __name__ == "__main__":

--- a/conformance/scripts/vector_runner.py
+++ b/conformance/scripts/vector_runner.py
@@ -879,7 +879,12 @@ class VectorRunner:
                         for line in r.error.split("\n"):
                             self.log(f"    {line}")
 
-        if not self.results and not self.version_skips:
+        if not self.results:
+            skip_detail = (
+                f" ({self.version_skips} scenario(s) were version-skipped)"
+                if self.version_skips
+                else ""
+            )
             self._record_result(
                 vector_file="runner",
                 test_type=TestType.BUILD,
@@ -889,7 +894,7 @@ class VectorRunner:
                 description="Runner executes at least one conformance check",
                 expected="at least one conformance check",
                 actual=0,
-                error="No conformance checks were executed",
+                error=f"No conformance checks were executed{skip_detail}",
             )
 
         # Compute summary


### PR DESCRIPTION
Fixes #79

## Problem

`VectorRunner.run()` guards against zero-check runs:

```python
if not self.results and not self.version_skips:
    self._record_result(..., error="No conformance checks were executed")
```

When `version_skips > 0` the condition short-circuits, leaving `self.results`
empty. The summary computes `failed = 0`, prints "PASSED: 0 passed, 0 total",
and exits 0 — a fully-skipped run is indistinguishable from a passing run.

## Fix

Drop the `version_skips` half of the guard. An empty result set is always
wrong regardless of skip count. When skips are present, the count appears
in the error message for clarity.

**Before:**

PASSED: 0 passed, 0 total ← exit 0, silent


**After:**

FAILED: 0 passed, 1 failed, 1 total

Failures:

runner::build::no_checks
No conformance checks were executed (3 scenario(s) were version-skipped)