### PR TITLE
fix: persist Agricola state through pull request

### DIFF
--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: agricola-control-plane
@@ -22,14 +22,21 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      STATE_BRANCH: agricola/state
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - name: Restore control-plane state
+        run: |
+          if git fetch origin "refs/heads/$STATE_BRANCH:refs/remotes/origin/$STATE_BRANCH"; then
+            git restore --source "origin/$STATE_BRANCH" -- ledger
+          fi
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -48,20 +55,29 @@ jobs:
           fi
 
       - name: Persist control-plane state
-        run: |
-          if [ -z "$(git status --porcelain -- ledger)" ]; then
-            exit 0
-          fi
-          git config user.name "agricola[bot]"
-          git config user.email "agricola[bot]@users.noreply.github.com"
-          git add ledger
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            git commit -m "chore: record agricola decision"
-          else
-            git commit -m "chore: advance agricola control plane"
-          fi
-          git pull --rebase origin "$DEFAULT_BRANCH"
-          git push origin "HEAD:$DEFAULT_BRANCH"
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ github.token }}
+          base: ${{ env.DEFAULT_BRANCH }}
+          branch: ${{ env.STATE_BRANCH }}
+          commit-message: "chore: update Agricola state"
+          title: "chore: update Agricola state"
+          body: |
+            ## Motivation
+
+            Persist Agricola's durable cursor and decision ledger through the repository's required pull-request path.
+
+            ## Summary
+
+            - tracks the latest processed canonical merge
+            - records immutable source snapshots and maintainer decisions
+
+            ## Key design considerations
+
+            - workflow code always executes from the protected default branch
+            - this pull request is updated in place as state advances
+          add-paths: ledger
+          delete-branch: false
 
       - name: Deliver command reply
         if: github.event_name == 'issue_comment'

--- a/agricola/README.md
+++ b/agricola/README.md
@@ -93,7 +93,7 @@ Commands in canonical or downstream repositories require cross-repository event 
 
 ## State and recovery
 
-The poller creates `ledger/cursor.json` on its first run. The initial cursor starts fifteen minutes behind the current time; combined with the one-hour replay overlap, the first API read covers approximately the previous 75 minutes. This prevents both a deployment race and an unbounded historical issue flood. Later polls keep the one-hour overlap and deduplicate against ledger snapshots.
+The poller creates `ledger/cursor.json` on its first run. In GitHub Actions, ledger data is restored from `agricola/state`, and a stable state pull request is updated in place like a changelogs release PR. Executable code always comes from the protected default branch. The initial cursor starts fifteen minutes behind the current time; combined with the one-hour replay overlap, the first API read covers approximately the previous 75 minutes. This prevents both a deployment race and an unbounded historical issue flood. Later polls keep the one-hour overlap and deduplicate against ledger snapshots.
 
 Ledger filenames identify the canonical repository and pull request. Entries contain immutable source metadata, the authorized merge-time label snapshot, and discriminated decisions:
 
@@ -105,10 +105,10 @@ Tracking issue deduplication scans the control repository's issue API directly f
 The Actions workflow processes state-changing commands in three stages:
 
 1. prepare the ledger mutation and pending reply;
-2. commit and push the ledger to the default branch;
+2. commit the ledger to the stable state branch and create or update its pull request;
 3. deliver the GitHub reply only after persistence succeeds.
 
-A failed rebase or push therefore cannot leave a misleading “Recorded” acknowledgement. Rerunning the failed job reuses the comment-and-line idempotency key.
+A failed state PR update therefore cannot leave a misleading “Recorded” acknowledgement. Rerunning the failed job reuses the comment-and-line idempotency key.
 
 ## CLI reference
 

--- a/docs/agricola-actions.md
+++ b/docs/agricola-actions.md
@@ -10,7 +10,7 @@ Agricola runs from [`.github/workflows/agricola.yml`](../.github/workflows/agric
 | `workflow_dispatch` | Run the poller manually. |
 | New `issue_comment` containing `@agricola` | Validate and handle a tracking-issue command. The parser still requires `@agricola` as the first token on a line. |
 
-One concurrency group serializes all triggers. Runs check out the repository's current default branch rather than assuming `main`.
+One concurrency group serializes all triggers. Runs execute trusted code from the repository's current default branch rather than assuming `main`. Durable ledger data is restored from `agricola/state`, and the changelogs-style PR updater keeps one open state pull request current. Code from the state branch is never executed.
 
 ## Required permissions
 
@@ -18,9 +18,9 @@ The workflow declares:
 
 - `contents: write` to persist the cursor and decision ledger;
 - `issues: write` to create tracking issues, update plans, and deliver command replies;
-- `pull-requests: read` to inspect canonical changes and query live status.
+- `pull-requests: write` to inspect canonical changes, query live status, and maintain the state pull request.
 
-The repository's Actions settings must allow `GITHUB_TOKEN` write access. Branch rules must permit the bot-authored ledger commit or provide an approved equivalent update path. If the default branch rejects the push, the workflow fails before delivering a state-changing command acknowledgement.
+The repository's Actions settings must allow `GITHUB_TOKEN` write access and pull-request creation. Agricola uses the same stable-branch pattern as the changelogs release action: `peter-evans/create-pull-request` creates or updates `agricola/state` and its single state pull request. No direct default-branch push or branch-rule exception is required. If the state PR update fails, the workflow stops before delivering a state-changing command acknowledgement.
 
 The canonical repository must be publicly readable by this token. Private or cross-organization repositories require an appropriately scoped GitHub App or token and are outside the secret-free setup.
 
@@ -29,11 +29,11 @@ The canonical repository must be publicly readable by this token. Private or cro
 1. Review [`sdks.yaml`](../sdks.yaml), especially `maintainers`, repository names, automation modes, verification commands, and capabilities.
 2. Create canonical labels `agricola:all`, `agricola:none`, and `agricola:<target>` for each desired manifest target. Agricola validates labels but does not create them.
 3. Enable GitHub Actions and workflow write permissions in `mpp-tools`.
-4. Ensure branch rules allow the `agricola[bot]` ledger commit.
-5. Run the workflow manually once and confirm that `ledger/cursor.json` is committed.
+4. Ensure Actions can create pull requests and write to non-default branches.
+5. Run the workflow manually once and confirm that the Agricola state PR contains `ledger/cursor.json`.
 6. Run `agricola validate` locally or inspect the workflow's validation step.
 
-The initial cursor starts fifteen minutes in the past. Because every poll also replays a one-hour overlap, the first API read covers approximately the previous 75 minutes. To intentionally backfill a different window, commit a reviewed `ledger/cursor.json` containing a timezone-aware ISO 8601 `merged_at` timestamp; polling begins one hour before that value.
+The initial cursor starts fifteen minutes in the past. Because every poll also replays a one-hour overlap, the first API read covers approximately the previous 75 minutes. To intentionally backfill a different window, update the state PR with a reviewed `ledger/cursor.json` containing a timezone-aware ISO 8601 `merged_at` timestamp; polling begins one hour before that value.
 
 ## Labels and authorization
 
@@ -71,4 +71,4 @@ Mention commands, including `@agricola status`, are scoped to Agricola tracking 
 - A command has no reply: inspect the persistence step. Replies are intentionally skipped after a failed ledger push.
 - A command is ignored: confirm the commenter is in `maintainers`, `@agricola` begins a line, the verb is currently supported, and the issue contains an Agricola source marker.
 - A label is ignored: confirm its final application occurred before merge and was performed by a configured maintainer.
-- The default branch rejects the ledger commit: adjust the branch rule or provide an approved write path before retrying the run.
+- The state PR is not created or updated: confirm that Actions has `contents: write`, `pull-requests: write`, and permission to create pull requests.


### PR DESCRIPTION
## Motivation

The organization ruleset requires default-branch changes to arrive through pull requests, so Agricola cannot persist its cursor directly to `main`.

## Summary

- restore cursor and ledger data from a stable `agricola/state` branch
- create or update one state pull request using the same action as changelogs
- update Actions versions and deployment documentation

## Key design considerations

- execute workflow code only from the protected default branch
- validate restored ledger data before processing events
- persist cursor and ledger changes atomically before delivering command replies