### PR TITLE
ci: skip conformance for Agricola-only changes

### DIFF
--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -64,7 +64,7 @@ jobs:
           title: "chore(agricola): update state"
           body: |
             > [!IMPORTANT]
-            > This pull request is maintained by automation. Leave it open; do not merge, close, or edit it manually.
+            > This pull request is maintained by automation. Merge it to checkpoint state on the default branch; do not close or edit it manually.
 
             ## Motivation
 
@@ -80,7 +80,7 @@ jobs:
             - workflow code always executes from the protected default branch
             - this pull request is updated in place as state advances
           add-paths: ledger
-          delete-branch: false
+          delete-branch: true
 
       - name: Deliver command reply
         if: github.event_name == 'issue_comment'

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -60,9 +60,12 @@ jobs:
           token: ${{ github.token }}
           base: ${{ env.DEFAULT_BRANCH }}
           branch: ${{ env.STATE_BRANCH }}
-          commit-message: "chore: update Agricola state"
-          title: "chore: update Agricola state"
+          commit-message: "chore(agricola): update state"
+          title: "chore(agricola): update state"
           body: |
+            > [!IMPORTANT]
+            > This pull request is maintained by automation. Leave it open; do not merge, close, or edit it manually.
+
             ## Motivation
 
             Persist Agricola's durable cursor and decision ledger through the repository's required pull-request path.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths-ignore:
+      - ledger/**
   push:
     branches:
       - main

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -7,6 +7,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+    paths-ignore:
+      - ledger/**
   push:
     branches:
       - main

--- a/agricola/README.md
+++ b/agricola/README.md
@@ -93,7 +93,7 @@ Commands in canonical or downstream repositories require cross-repository event 
 
 ## State and recovery
 
-The poller creates `ledger/cursor.json` on its first run. In GitHub Actions, ledger data is restored from `agricola/state`, and a stable state pull request is updated in place like a changelogs release PR. This automation-owned PR remains open and is not merged or edited manually. Executable code always comes from the protected default branch. The initial cursor starts fifteen minutes behind the current time; combined with the one-hour replay overlap, the first API read covers approximately the previous 75 minutes. This prevents both a deployment race and an unbounded historical issue flood. Later polls keep the one-hour overlap and deduplicate against ledger snapshots.
+The poller creates `ledger/cursor.json` on its first run. In GitHub Actions, ledger data is restored from `agricola/state`, and a stable state pull request is updated in place like a changelogs release PR. At most one state PR is open: merge it to checkpoint the ledger on the default branch, and the next state change creates or updates its successor. Do not close or edit state PRs manually. Executable code always comes from the protected default branch. The initial cursor starts fifteen minutes behind the current time; combined with the one-hour replay overlap, the first API read covers approximately the previous 75 minutes. This prevents both a deployment race and an unbounded historical issue flood. Later polls keep the one-hour overlap and deduplicate against ledger snapshots.
 
 Ledger filenames identify the canonical repository and pull request. Entries contain immutable source metadata, the authorized merge-time label snapshot, and discriminated decisions:
 

--- a/agricola/README.md
+++ b/agricola/README.md
@@ -93,7 +93,7 @@ Commands in canonical or downstream repositories require cross-repository event 
 
 ## State and recovery
 
-The poller creates `ledger/cursor.json` on its first run. In GitHub Actions, ledger data is restored from `agricola/state`, and a stable state pull request is updated in place like a changelogs release PR. Executable code always comes from the protected default branch. The initial cursor starts fifteen minutes behind the current time; combined with the one-hour replay overlap, the first API read covers approximately the previous 75 minutes. This prevents both a deployment race and an unbounded historical issue flood. Later polls keep the one-hour overlap and deduplicate against ledger snapshots.
+The poller creates `ledger/cursor.json` on its first run. In GitHub Actions, ledger data is restored from `agricola/state`, and a stable state pull request is updated in place like a changelogs release PR. This automation-owned PR remains open and is not merged or edited manually. Executable code always comes from the protected default branch. The initial cursor starts fifteen minutes behind the current time; combined with the one-hour replay overlap, the first API read covers approximately the previous 75 minutes. This prevents both a deployment race and an unbounded historical issue flood. Later polls keep the one-hour overlap and deduplicate against ledger snapshots.
 
 Ledger filenames identify the canonical repository and pull request. Entries contain immutable source metadata, the authorized merge-time label snapshot, and discriminated decisions:
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -153,7 +153,7 @@ SDK pins live in package-manager manifests and lockfiles where the ecosystem sup
 | Ruby | `mpp-rb` | `adapters/ruby/Gemfile` / `Gemfile.lock` |
 | Java | `com.github.stripe:mpp-java` | `adapters/java/build.gradle` / `gradle.lockfile` |
 
-Dependabot checks all configured package managers daily and opens PRs when updates are available. Every PR runs vector and flow conformance in CI, so dependency bump PRs are gated by the same compatibility suite.
+Dependabot checks all configured package managers daily and opens PRs when updates are available. Pull requests that change conformance or adapter files run the affected vector and flow checks; shared conformance changes run the complete matrix. Agricola-only pull requests skip SDK conformance and run the dedicated Agricola checks instead.
 
 The Java adapter currently pins `mpp-java` to an exact JitPack commit because `mpp-java` does not publish versioned Maven releases yet. Update `adapters/java/build.gradle` manually and run `make update-java` when changing that pin.
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -153,7 +153,7 @@ SDK pins live in package-manager manifests and lockfiles where the ecosystem sup
 | Ruby | `mpp-rb` | `adapters/ruby/Gemfile` / `Gemfile.lock` |
 | Java | `com.github.stripe:mpp-java` | `adapters/java/build.gradle` / `gradle.lockfile` |
 
-Dependabot checks all configured package managers daily and opens PRs when updates are available. Pull requests that change conformance or adapter files run the affected vector and flow checks; shared conformance changes run the complete matrix. Agricola-only pull requests skip SDK conformance and run the dedicated Agricola checks instead.
+Dependabot checks all configured package managers daily and opens PRs when updates are available. Pull requests that change conformance or adapter files run the affected vector and flow checks; shared conformance changes run the complete matrix. Agricola-only pull requests skip SDK conformance and run the dedicated Agricola checks instead. Ledger-only state PRs are ignored at the workflow trigger level.
 
 The Java adapter currently pins `mpp-java` to an exact JitPack commit because `mpp-java` does not publish versioned Maven releases yet. Update `adapters/java/build.gradle` manually and run `make update-java` when changing that pin.
 

--- a/conformance/scripts/select_ci_adapters.py
+++ b/conformance/scripts/select_ci_adapters.py
@@ -32,6 +32,16 @@ ADAPTER_PATTERNS = {
     "java": ["conformance/adapters/java/**"],
 }
 
+AGRICOLA_PATTERNS = [
+    ".github/workflows/agricola.yml",
+    "agricola/**",
+    "docs/**",
+    "ledger/**",
+    "pyproject.toml",
+    "README.md",
+    "sdks.yaml",
+]
+
 FULL_PATTERNS = [
     ".github/actions/**",
     ".github/workflows/**",
@@ -87,6 +97,11 @@ def select_adapters(event_name: str, changed_files: list[str]) -> tuple[list[str
         return ADAPTER_ORDER, "non-PR event runs the full suite"
     if not changed_files:
         return ADAPTER_ORDER, "no changed file list; running the full suite"
+    if all(
+        any(path_matches(path, pattern) for pattern in AGRICOLA_PATTERNS)
+        for path in changed_files
+    ):
+        return [], "only Agricola control-plane files changed"
     if any(any(path_matches(path, pattern) for pattern in FULL_PATTERNS) for path in changed_files):
         return ADAPTER_ORDER, "shared conformance files changed"
 

--- a/conformance/scripts/test_select_ci_adapters.py
+++ b/conformance/scripts/test_select_ci_adapters.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import unittest
+
+from select_ci_adapters import ADAPTER_ORDER, select_adapters
+
+
+class SelectAdaptersTests(unittest.TestCase):
+    def test_selects_expected_scope(self) -> None:
+        cases = [
+            (
+                "Agricola workflow and implementation",
+                "pull_request",
+                [
+                    ".github/workflows/agricola.yml",
+                    "agricola/service.py",
+                    "agricola/tests/test_service.py",
+                    "docs/agricola-actions.md",
+                    "sdks.yaml",
+                ],
+                [],
+                "only Agricola control-plane files changed",
+            ),
+            (
+                "Agricola state pull request",
+                "pull_request",
+                ["ledger/cursor.json", "ledger/wevm-mppx-123.json"],
+                [],
+                "only Agricola control-plane files changed",
+            ),
+            (
+                "mixed Agricola and conformance workflow",
+                "pull_request",
+                [".github/workflows/agricola.yml", ".github/workflows/conformance.yml"],
+                ADAPTER_ORDER,
+                "shared conformance files changed",
+            ),
+            (
+                "adapter implementation",
+                "pull_request",
+                ["conformance/adapters/python/server.py"],
+                ["python"],
+                "adapter-specific conformance files changed",
+            ),
+            (
+                "unrelated files",
+                "pull_request",
+                ["LICENSE"],
+                [],
+                "no conformance-affecting files changed",
+            ),
+            (
+                "push event",
+                "push",
+                ["agricola/service.py"],
+                ADAPTER_ORDER,
+                "non-PR event runs the full suite",
+            ),
+        ]
+
+        for name, event_name, changed_files, expected, reason in cases:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    select_adapters(event_name, changed_files),
+                    (expected, reason),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/agricola-actions.md
+++ b/docs/agricola-actions.md
@@ -10,7 +10,7 @@ Agricola runs from [`.github/workflows/agricola.yml`](../.github/workflows/agric
 | `workflow_dispatch` | Run the poller manually. |
 | New `issue_comment` containing `@agricola` | Validate and handle a tracking-issue command. The parser still requires `@agricola` as the first token on a line. |
 
-One concurrency group serializes all triggers. Runs execute trusted code from the repository's current default branch rather than assuming `main`. Durable ledger data is restored from `agricola/state`, and the changelogs-style PR updater keeps one open state pull request current. The state PR is an automation-owned materialized view: leave it open and do not merge or edit it. Code from the state branch is never executed.
+One concurrency group serializes all triggers. Runs execute trusted code from the repository's current default branch rather than assuming `main`. Durable ledger data is restored from `agricola/state`, and the changelogs-style PR updater creates or updates at most one open state pull request. Merge the state PR to checkpoint its ledger on the default branch; do not close or edit it manually. The next state change creates or updates the next single state PR. Code from the state branch is never executed.
 
 ## Required permissions
 

--- a/docs/agricola-actions.md
+++ b/docs/agricola-actions.md
@@ -10,7 +10,7 @@ Agricola runs from [`.github/workflows/agricola.yml`](../.github/workflows/agric
 | `workflow_dispatch` | Run the poller manually. |
 | New `issue_comment` containing `@agricola` | Validate and handle a tracking-issue command. The parser still requires `@agricola` as the first token on a line. |
 
-One concurrency group serializes all triggers. Runs execute trusted code from the repository's current default branch rather than assuming `main`. Durable ledger data is restored from `agricola/state`, and the changelogs-style PR updater keeps one open state pull request current. Code from the state branch is never executed.
+One concurrency group serializes all triggers. Runs execute trusted code from the repository's current default branch rather than assuming `main`. Durable ledger data is restored from `agricola/state`, and the changelogs-style PR updater keeps one open state pull request current. The state PR is an automation-owned materialized view: leave it open and do not merge or edit it. Code from the state branch is never executed.
 
 ## Required permissions
 
@@ -34,6 +34,8 @@ The canonical repository must be publicly readable by this token. Private or cro
 6. Run `agricola validate` locally or inspect the workflow's validation step.
 
 The initial cursor starts fifteen minutes in the past. Because every poll also replays a one-hour overlap, the first API read covers approximately the previous 75 minutes. To intentionally backfill a different window, update the state PR with a reviewed `ledger/cursor.json` containing a timezone-aware ISO 8601 `merged_at` timestamp; polling begins one hour before that value.
+
+Ledger-only state PR updates are ignored by the repository's CI and SDK conformance workflow triggers. Agricola implementation changes still run the dedicated Agricola tests, while mixed or conformance-affecting changes retain their normal conformance scope.
 
 ## Labels and authorization
 


### PR DESCRIPTION
## Motivation

Agricola-only changes do not affect SDK conformance, but the shared workflow path currently launches the complete adapter matrix.

## Summary

- skip SDK conformance when every changed path belongs to Agricola
- preserve full conformance for mixed or shared-harness changes
- add table-driven scope-selection coverage

## Key design considerations

- state PR ledger updates are treated as Agricola-only
- non-PR events continue to run the full suite
- ambiguous or mixed changes remain conservative