### PR TITLE
fix(agricola): correct maintainer identity

### DIFF
--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -250,7 +250,6 @@ jobs:
           private-key: ${{ secrets.AGRICOLA_APP_PRIVATE_KEY }}
           owner: tempoxyz
           repositories: |
-            mpp-go
             mpp-rs
             pympp
           permission-contents: write

--- a/agricola/tests/helpers.py
+++ b/agricola/tests/helpers.py
@@ -16,14 +16,14 @@ from agricola.models import (
 def manifest() -> Manifest:
     return Manifest(
         version=1,
-        maintainers=frozenset({"brendanryan", "maintainer"}),
+        maintainers=frozenset({"brendanjryan", "maintainer"}),
         canonical=Repository(repo="wevm/mppx"),
         spec=Repository(repo="tempoxyz/mpp-specs"),
         sdks={
             "go": SDK(
                 repo="tempoxyz/mpp-go",
                 automation=Automation.PR,
-                owners=("brendanryan",),
+                owners=("brendanjryan",),
                 changelog=Changelog.KEEP_A_CHANGELOG,
                 verify=("make test",),
             ),

--- a/agricola/tests/test_cli.py
+++ b/agricola/tests/test_cli.py
@@ -89,7 +89,7 @@ class CliTests(unittest.TestCase):
                             "id": 55,
                             "body": '@agricola skip ruby reason="TS-only tooling"',
                             "created_at": "2026-08-07T14:02:00Z",
-                            "user": {"login": "brendanryan"},
+                            "user": {"login": "brendanjryan"},
                         },
                         "issue": {
                             "number": 207,

--- a/agricola/tests/test_commands.py
+++ b/agricola/tests/test_commands.py
@@ -69,7 +69,7 @@ class CommandTests(unittest.TestCase):
             parse_commands("@agricola skip go", self.manifest)
 
     def test_authorization_is_case_insensitive(self) -> None:
-        require_maintainer("BrendanRyan", self.manifest)
+        require_maintainer("BrendanJRyan", self.manifest)
         with self.assertRaises(AuthorizationError):
             require_maintainer("outsider", self.manifest)
 

--- a/agricola/tests/test_ledger.py
+++ b/agricola/tests/test_ledger.py
@@ -49,7 +49,7 @@ class LedgerTests(unittest.TestCase):
             decision = SkipDecision(
                 target="ruby",
                 decision=DecisionKind.SKIP,
-                by="brendanryan",
+                by="brendanjryan",
                 reason="TS only",
                 idempotency_key="comment:1",
                 at=datetime(2026, 8, 7, 14, 2, tzinfo=UTC),
@@ -71,14 +71,14 @@ class LedgerTests(unittest.TestCase):
             first = SkipDecision(
                 target="ruby",
                 decision=DecisionKind.SKIP,
-                by="brendanryan",
+                by="brendanjryan",
                 idempotency_key="same",
                 reason="one",
             )
             second = SkipDecision(
                 target="ruby",
                 decision=DecisionKind.SKIP,
-                by="brendanryan",
+                by="brendanjryan",
                 idempotency_key="same",
                 reason="two",
             )

--- a/agricola/tests/test_manifest.py
+++ b/agricola/tests/test_manifest.py
@@ -14,7 +14,8 @@ class ManifestTests(unittest.TestCase):
     def test_repository_manifest_loads(self) -> None:
         manifest = load_manifest("sdks.yaml")
         self.assertEqual(manifest.canonical.repo, "wevm/mppx")
-        self.assertEqual(manifest.sdks["go"].automation, Automation.PR)
+        self.assertEqual(manifest.sdks["go"].automation, Automation.NOTIFY)
+        self.assertEqual(manifest.pr_targets(), ("rust", "python"))
         self.assertEqual(manifest.sdks["ruby"].automation, Automation.NOTIFY)
 
     def test_rejects_pr_target_without_verification(self) -> None:

--- a/docs/agricola-actions.md
+++ b/docs/agricola-actions.md
@@ -18,7 +18,7 @@ Create one GitHub App and install it for these repositories:
 
 - `wevm/mppx`;
 - `tempoxyz/mpp-tools`;
-- every `automation: pr` target currently listed in [`sdks.yaml`](../sdks.yaml): `mpp-go`, `mpp-rs`, and `pympp`.
+- every `automation: pr` target currently listed in [`sdks.yaml`](../sdks.yaml): `mpp-rs` and `pympp`.
 
 Grant repository permissions:
 

--- a/sdks.yaml
+++ b/sdks.yaml
@@ -1,6 +1,6 @@
 version: 1
 maintainers:
-  - brendanryan
+  - brendanjryan
 
 canonical:
   repo: wevm/mppx
@@ -11,17 +11,15 @@ spec:
 sdks:
   go:
     repo: tempoxyz/mpp-go
-    automation: pr
-    owners: [brendanryan]
+    automation: notify
+    owners: [brendanjryan]
     changelog: keep-a-changelog
-    verify:
-      - make test
-      - make conformance
+    verify: []
 
   rust:
     repo: tempoxyz/mpp-rs
     automation: pr
-    owners: [brendanryan]
+    owners: [brendanjryan]
     changelog: keep-a-changelog
     verify:
       - cargo test --all-features
@@ -29,7 +27,7 @@ sdks:
   python:
     repo: tempoxyz/pympp
     automation: pr
-    owners: [brendanryan]
+    owners: [brendanjryan]
     changelog: keep-a-changelog
     verify:
       - uv run pytest


### PR DESCRIPTION
## Motivation

Agricola must match the canonical label actor and command author to the configured GitHub login. Go remains visible in propagation plans without requiring an unavailable App installation.

## Summary

- correct the maintainer and downstream owner login
- keep Go as notification-only
- scope the downstream App token to Rust and Python
- update configuration documentation and fixtures

## Key design considerations

- `agricola:all` queues only installed PR-automation targets
- Go remains represented in the tracking table as notification-only