### PR TITLE
feat(agricola): add recurring SDK drift audit

### DIFF
--- a/.github/workflows/agricola-audit.yml
+++ b/.github/workflows/agricola-audit.yml
@@ -1,0 +1,257 @@
+name: Agricola SDK audit
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: agricola-control-plane
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      canonical-repo: ${{ steps.matrix.outputs.canonical-repo }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Build audit matrix
+        id: matrix
+        run: |
+          pip install .
+          matrix="$(agricola audit-matrix | jq -c .)"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "canonical-repo=$(python -c 'from agricola.manifest import load_manifest; print(load_manifest().canonical.repo)')" >> "$GITHUB_OUTPUT"
+
+  canonical:
+    name: audit (typescript reference)
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout audit control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Checkout canonical SDK head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ needs.prepare.outputs.canonical-repo }}
+          path: .audit/sdk
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup conformance adapter
+        uses: ./.github/actions/setup-conformance
+        with:
+          adapter: typescript
+
+      - name: Install audit and conformance runner
+        run: |
+          pip install .
+          uv sync --locked --project conformance --python 3.12
+
+      - name: Point adapter at canonical checkout
+        run: |
+          uv run --locked --project conformance python conformance/scripts/use_local_sdk.py \
+            --adapter typescript \
+            --sdk-path .audit/sdk
+
+      - name: Build canonical SDK and adapter
+        run: |
+          corepack enable
+          cd .audit/sdk
+          pnpm install --frozen-lockfile
+          pnpm build
+          cd ../../conformance
+          npm install
+
+      - name: Run canonical vectors
+        run: |
+          set +e
+          uv run --locked --project conformance python conformance/scripts/vector_runner.py \
+            --adapter typescript \
+            --output json \
+            > "$RUNNER_TEMP/canonical-results.json"
+          status=$?
+          set -e
+          echo "Canonical vector runner exited $status"
+
+      - name: Build canonical snapshot
+        run: |
+          mkdir -p "$RUNNER_TEMP/snapshots"
+          agricola audit-snapshot \
+            --target typescript \
+            --repo "${{ needs.prepare.outputs.canonical-repo }}" \
+            --sha "$(git -C .audit/sdk rev-parse HEAD)" \
+            --adapter-manifest conformance/adapters/typescript/adapter.json \
+            --results "$RUNNER_TEMP/canonical-results.json" \
+            > "$RUNNER_TEMP/snapshots/typescript.json"
+
+      - name: Upload canonical snapshot
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: agricola-audit-snapshot-typescript
+          path: ${{ runner.temp }}/snapshots/typescript.json
+          if-no-files-found: warn
+
+  target:
+    name: audit (${{ matrix.target }})
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    steps:
+      - name: Checkout audit control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Checkout SDK head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: ${{ matrix.repo }}
+          path: .audit/sdk
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup conformance adapter
+        uses: ./.github/actions/setup-conformance
+        with:
+          adapter: ${{ matrix.target }}
+          ruby-bundler-cache: "false"
+
+      - name: Install audit and conformance runner
+        run: |
+          pip install .
+          uv sync --locked --project conformance --python 3.12
+
+      - name: Build Java SDK checkout
+        if: matrix.target == 'java'
+        working-directory: .audit/sdk
+        run: ./gradlew --no-daemon jar
+
+      - name: Point adapter at SDK checkout
+        run: |
+          uv run --locked --project conformance python conformance/scripts/use_local_sdk.py \
+            --adapter "${{ matrix.target }}" \
+            --sdk-path .audit/sdk
+
+      - name: Run SDK vectors
+        run: |
+          set +e
+          uv run --locked --project conformance python conformance/scripts/vector_runner.py \
+            --adapter "${{ matrix.target }}" \
+            --output json \
+            > "$RUNNER_TEMP/target-results.json"
+          status=$?
+          set -e
+          echo "${{ matrix.target }} vector runner exited $status"
+
+      - name: Build SDK snapshot
+        run: |
+          mkdir -p "$RUNNER_TEMP/snapshots"
+          agricola audit-snapshot \
+            --target "${{ matrix.target }}" \
+            --repo "${{ matrix.repo }}" \
+            --sha "$(git -C .audit/sdk rev-parse HEAD)" \
+            --adapter-manifest "conformance/adapters/${{ matrix.target }}/adapter.json" \
+            --results "$RUNNER_TEMP/target-results.json" \
+            > "$RUNNER_TEMP/snapshots/${{ matrix.target }}.json"
+
+      - name: Upload SDK snapshot
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: agricola-audit-snapshot-${{ matrix.target }}
+          path: ${{ runner.temp }}/snapshots/${{ matrix.target }}.json
+          if-no-files-found: warn
+
+  report:
+    needs: [prepare, canonical, target]
+    if: always() && needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    env:
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      STATE_BRANCH: agricola/state
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
+      - name: Restore control-plane state
+        run: |
+          if git fetch origin "refs/heads/$STATE_BRANCH:refs/remotes/origin/$STATE_BRANCH"; then
+            git restore --source "origin/$STATE_BRANCH" -- ledger
+          fi
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install Agricola
+        run: pip install .
+
+      - name: Download audit snapshots
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: agricola-audit-snapshot-*
+          path: ${{ runner.temp }}/snapshots
+          merge-multiple: true
+
+      - name: Build audit roll-up
+        run: |
+          mkdir -p "$RUNNER_TEMP/snapshots"
+          agricola build-audit "$RUNNER_TEMP/snapshots" \
+            --report-file "$RUNNER_TEMP/audit-report.json"
+          cat "$RUNNER_TEMP/audit-report.json"
+
+      - name: Persist audit registry
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ github.token }}
+          base: ${{ env.DEFAULT_BRANCH }}
+          branch: ${{ env.STATE_BRANCH }}
+          commit-message: "chore(agricola): update state"
+          title: "chore(agricola): update state"
+          body: |
+            > [!IMPORTANT]
+            > This pull request is maintained by automation. Merge it to checkpoint state on the default branch; do not close or edit it manually.
+
+            ## Motivation
+
+            Persist Agricola's durable cursor, decisions, and audit finding registry through the repository's required pull-request path.
+
+            ## Summary
+
+            - tracks the latest processed canonical merge
+            - records immutable source snapshots and maintainer decisions
+            - assigns stable IDs to recurring audit findings
+
+            ## Key design considerations
+
+            - workflow code always executes from the protected default branch
+            - this pull request is updated in place as state advances
+          add-paths: ledger
+          delete-branch: true
+
+      - name: Update audit issue
+        run: agricola deliver-audit "$RUNNER_TEMP/audit-report.json"
+
+      - name: Require complete audit
+        run: jq -e '.healthy == true' "$RUNNER_TEMP/audit-report.json" >/dev/null

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ mpp-tools/
 
 ## Agricola
 
-[Agricola](./agricola/README.md) is the propagation control plane for canonical SDK changes. It creates deterministic tracking plans, reconstructs authorized merge-time labels, verifies generated downstream changes, opens draft SDK pull requests, and records maintainer decisions. Its deployment runbook is [docs/agricola-actions.md](./docs/agricola-actions.md).
+[Agricola](./agricola/README.md) is the propagation and drift-audit control plane for canonical SDK changes. It creates deterministic tracking plans, reconstructs authorized merge-time labels, verifies generated downstream changes, opens draft SDK pull requests, records maintainer decisions, and maintains one head-to-head SDK audit roll-up. Its deployment runbook is [docs/agricola-actions.md](./docs/agricola-actions.md).
 
 ## Conformance Suite
 

--- a/agricola/README.md
+++ b/agricola/README.md
@@ -10,6 +10,7 @@ It:
 - creates one tracking issue per actionable canonical change;
 - accepts maintainer-only `plan`, `propagate`, `status`, and `skip` commands;
 - generates idiomatic downstream changes, runs each SDK's declared verification, and opens draft pull requests;
+- audits every SDK head against canonical `mppx`, clusters deterministic deltas, and updates one roll-up issue;
 - records immutable source snapshots and completed decisions under [`ledger/`](../ledger/).
 
 Agricola never auto-merges a downstream pull request. Maintainers retain review and merge control.
@@ -89,7 +90,7 @@ The tracking issue also contains a durable downstream propagation table. It list
 - `status` queries GitHub for downstream pull requests already recorded in the ledger.
 - `skip` appends an idempotent, reason-required decision for one manifest target.
 
-Commands in canonical or downstream repositories are not supported. Revision, retry, audit, and downstream issue commands remain manual operations. A failed unpublished propagation can be retried by rerunning its workflow; a published stable branch is updated idempotently.
+Commands in canonical or downstream repositories are not supported. Revision, retry, audit-finding actions, and downstream issue commands remain manual operations. A failed unpublished propagation can be retried by rerunning its workflow; a published stable branch is updated idempotently.
 
 ## Downstream execution
 
@@ -112,6 +113,14 @@ If the canonical behavior is absent from a target SDK, the generator returns an 
 
 Generation and verification failures leave no decision, so the same request remains retryable. Explicit skips and successful publications are recorded even when another target in the same matrix fails. A closed stable pull request must be reopened before retrying. An existing ready-for-review pull request is returned to draft before its branch is updated, and a merged pull request is treated as the completed result.
 
+## Recurring audit
+
+The weekly and manually dispatched audit is head-to-head and report-only. It uses `mppx` as the sole reference and evaluates every manifest SDK independently, including notification-only targets.
+
+The first pass runs shared protocol vectors against each repository's current default-branch checkout and compares the capabilities declared by its conformance adapter. The second pass clusters equivalent failures under SDK-independent fingerprints such as `capability:challenge.parse` or `vector:www-authenticate/basic/parse`. Stable `AGR-<year>-<sequence>` IDs are assigned in [`ledger/audit.json`](../ledger/audit.json).
+
+One `[Agricola] SDK drift audit` issue is updated in place. It shows the exact audited commits, affected and clean SDKs, likely-origin heuristic, and incomplete jobs. Findings never create branches, pull requests, or downstream issues automatically. Codex semantic comparison is intentionally omitted because the specification requires deterministic evidence to remain authoritative.
+
 ## State and recovery
 
 The poller creates `ledger/cursor.json` on its first run. GitHub Actions restores ledger data from `agricola/state` and updates one stable state pull request, following the changelog release-PR pattern. Merge that pull request to checkpoint the ledger on the default branch. Do not close or edit it manually. The next state change creates or updates its successor, so at most one state pull request remains open.
@@ -122,6 +131,8 @@ Ledger filenames identify the canonical repository and pull request. Entries con
 
 - `skip` requires a reason and forbids a pull-request reference;
 - `propagate` requires a downstream pull-request reference and is written only after publication.
+
+The separate `ledger/audit.json` registry maps stable fingerprints to finding IDs. It does not store mutable CI or pull-request lifecycle state.
 
 Tracking issue deduplication scans the control repository's issue API directly for the stable marker; it does not depend on search indexing.
 
@@ -138,6 +149,10 @@ State-changing replies are deferred until the state pull request has been update
 | `agricola deliver-reply <file>` | Deliver a reply deferred until after Git persistence. |
 | `agricola deliver-issue-update <file>` | Deliver a tracking issue body update deferred until after Git persistence. |
 | `agricola record-propagations <results>` | Record published pull requests or explicit skips and render deferred replies. |
+| `agricola audit-matrix` | Build the head-audit matrix from the manifest and conformance adapters. |
+| `agricola audit-snapshot` | Normalize one SDK's head conformance result. |
+| `agricola build-audit <snapshots>` | Cluster snapshots, assign stable finding IDs, and render the roll-up. |
+| `agricola deliver-audit <report>` | Create or update the single audit issue. |
 | `agricola verify-propagation <request>` | Run the target's reviewed verification commands. |
 | `agricola render-propagation <request>` | Render deterministic pull-request metadata. |
 | `agricola parse-command --author <login>` | Parse commands from standard input for diagnostics. |
@@ -160,5 +175,5 @@ With Ruff, `ty`, `uv`, Go, and Actionlint available:
 .venv/bin/ruff format --check agricola
 .venv/bin/ruff check agricola
 uvx ty check agricola
-go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/agricola.yml
+go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/agricola.yml .github/workflows/agricola-audit.yml
 ```

--- a/agricola/audit.py
+++ b/agricola/audit.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import ValidationError
+
+from .ledger import AuditStore
+from .models import (
+    AuditCheckStatus,
+    AuditFinding,
+    AuditObservation,
+    AuditReport,
+    AuditSnapshot,
+    Manifest,
+    PendingAuditReport,
+)
+
+AUDIT_MARKER = "<!-- agricola:audit -->"
+AUDIT_TITLE = "[Agricola] SDK drift audit"
+
+
+class AuditError(ValueError):
+    pass
+
+
+class GitHub(Protocol):
+    def find_tracking_issue(self, marker: str) -> dict[str, object] | None: ...
+    def create_issue(
+        self, title: str, body: str, labels: Sequence[str] = ()
+    ) -> dict[str, object]: ...
+    def update_issue(
+        self, number: int, *, title: str | None = None, body: str | None = None
+    ) -> dict[str, object]: ...
+
+
+@dataclass(frozen=True)
+class FindingDraft:
+    fingerprint: str
+    summary: str
+    reference: str | None
+    affected: tuple[str, ...]
+    clean: tuple[str, ...]
+    likely_origin: str
+
+
+@dataclass
+class _FindingGroup:
+    summary: str
+    reference: str | None
+    affected: set[str]
+    clean: set[str]
+
+
+def audit_matrix(
+    manifest: Manifest, adapters_root: str | Path
+) -> dict[str, list[dict[str, str]]]:
+    root = Path(adapters_root)
+    include = []
+    missing = []
+    for target, sdk in manifest.sdks.items():
+        if not (root / target / "adapter.json").is_file():
+            missing.append(target)
+            continue
+        include.append(
+            {
+                "target": target,
+                "repo": sdk.repo,
+                "automation": sdk.automation.value,
+            }
+        )
+    if missing:
+        raise AuditError(
+            "manifest targets have no conformance adapter: " + ", ".join(missing)
+        )
+    return {"include": include}
+
+
+def snapshot_from_conformance(
+    *,
+    target: str,
+    repo: str,
+    sha: str,
+    adapter_manifest: Mapping[str, object],
+    results: Mapping[str, object],
+) -> AuditSnapshot:
+    capabilities = adapter_manifest.get("capabilities")
+    if not isinstance(capabilities, list) or not all(
+        isinstance(item, str) and item for item in capabilities
+    ):
+        raise AuditError("adapter manifest capabilities must be non-empty strings")
+    raw_checks = results.get("checks")
+    if not isinstance(raw_checks, list):
+        raise AuditError("conformance results checks must be an array")
+
+    observations: list[AuditObservation] = []
+    errors: list[str] = []
+    for raw in raw_checks:
+        if not isinstance(raw, dict):
+            raise AuditError("conformance result check must be an object")
+        details = raw.get("details")
+        if not isinstance(details, dict):
+            raise AuditError("conformance result check details must be an object")
+        vector = str(details.get("vector") or "")
+        scenario = str(details.get("scenario") or "")
+        test_type = str(details.get("testType") or "")
+        if not vector or not scenario or not test_type:
+            raise AuditError("conformance check is missing vector identity")
+        status = raw.get("status")
+        try:
+            check_status = AuditCheckStatus(str(status))
+        except ValueError as exc:
+            raise AuditError(f"invalid conformance check status: {status!r}") from exc
+        summary = str(raw.get("description") or raw.get("name") or scenario)
+        if vector in {"adapter", "runner"}:
+            if check_status is AuditCheckStatus.FAILURE:
+                errors.append(f"{target}: {summary}")
+            continue
+        references = raw.get("specReferences")
+        reference = None
+        if isinstance(references, list) and references:
+            first = references[0]
+            if isinstance(first, dict) and first.get("id"):
+                reference = str(first["id"])
+        observations.append(
+            AuditObservation(
+                fingerprint=(
+                    f"vector:{_component(vector)}/{_component(scenario)}/"
+                    f"{_component(test_type)}"
+                ),
+                status=check_status,
+                summary=summary,
+                reference=reference,
+            )
+        )
+    if not observations:
+        errors.append(f"{target}: no protocol conformance checks completed")
+    return AuditSnapshot(
+        target=target,
+        repo=repo,
+        sha=sha,
+        capabilities=frozenset(capabilities),
+        observations=tuple(observations),
+        errors=tuple(errors),
+    )
+
+
+def analyze_deltas(
+    canonical: AuditSnapshot,
+    targets: Sequence[AuditSnapshot],
+) -> tuple[tuple[FindingDraft, ...], tuple[str, ...]]:
+    errors = list(canonical.errors)
+    errors.extend(error for target in targets for error in target.errors)
+    canonical_checks = {
+        observation.fingerprint: observation for observation in canonical.observations
+    }
+    for observation in canonical.observations:
+        if observation.status is AuditCheckStatus.FAILURE:
+            errors.append(
+                f"canonical reference failed {observation.fingerprint}: "
+                f"{observation.summary}"
+            )
+
+    valid_targets = tuple(target for target in targets if not target.errors)
+    groups: dict[str, _FindingGroup] = {}
+
+    for capability in sorted(canonical.capabilities):
+        affected = {
+            target.target
+            for target in valid_targets
+            if capability not in target.capabilities
+        }
+        if affected:
+            fingerprint = f"capability:{capability}"
+            groups[fingerprint] = _FindingGroup(
+                summary=f"Canonical operation `{capability}` is not declared",
+                reference=capability,
+                affected=affected,
+                clean={
+                    target.target
+                    for target in valid_targets
+                    if capability in target.capabilities
+                },
+            )
+
+    for target in valid_targets:
+        for observation in target.observations:
+            canonical_observation = canonical_checks.get(observation.fingerprint)
+            if (
+                observation.status is not AuditCheckStatus.FAILURE
+                or canonical_observation is None
+                or canonical_observation.status is not AuditCheckStatus.SUCCESS
+            ):
+                continue
+            group = groups.setdefault(
+                observation.fingerprint,
+                _FindingGroup(
+                    summary=canonical_observation.summary,
+                    reference=canonical_observation.reference,
+                    affected=set(),
+                    clean=set(),
+                ),
+            )
+            group.affected.add(target.target)
+
+    for group_fingerprint, group in groups.items():
+        if group_fingerprint.startswith("capability:"):
+            continue
+        group.clean.update(
+            target.target
+            for target in valid_targets
+            if any(
+                observation.fingerprint == group_fingerprint
+                and observation.status is AuditCheckStatus.SUCCESS
+                for observation in target.observations
+            )
+        )
+
+    findings = []
+    for fingerprint, group in sorted(groups.items()):
+        affected = tuple(sorted(group.affected))
+        clean = tuple(sorted(group.clean))
+        findings.append(
+            FindingDraft(
+                fingerprint=fingerprint,
+                summary=group.summary,
+                reference=group.reference,
+                affected=affected,
+                clean=clean,
+                likely_origin=_likely_origin(len(affected), len(valid_targets)),
+            )
+        )
+    return tuple(findings), tuple(dict.fromkeys(errors))
+
+
+def build_audit_report(
+    manifest: Manifest,
+    snapshots: Sequence[AuditSnapshot],
+    store: AuditStore,
+    *,
+    at: datetime | None = None,
+) -> AuditReport:
+    generated_at = (at or datetime.now(UTC)).astimezone(UTC)
+    by_target = {snapshot.target: snapshot for snapshot in snapshots}
+    canonical = by_target.get("typescript")
+    if canonical is None:
+        raise AuditError("canonical typescript snapshot is missing")
+    missing = [target for target in manifest.sdks if target not in by_target]
+    targets = tuple(
+        by_target[target] for target in manifest.sdks if target in by_target
+    )
+    drafts, analysis_errors = analyze_deltas(canonical, targets)
+    errors = (
+        *(f"{target}: audit snapshot is missing" for target in missing),
+        *analysis_errors,
+    )
+    ids = store.assign((draft.fingerprint for draft in drafts), generated_at)
+    findings = tuple(
+        AuditFinding(
+            id=ids[draft.fingerprint],
+            fingerprint=draft.fingerprint,
+            summary=draft.summary,
+            reference=draft.reference,
+            affected=draft.affected,
+            clean=draft.clean,
+            likely_origin=draft.likely_origin,
+        )
+        for draft in drafts
+    )
+    return AuditReport(
+        generated_at=generated_at,
+        canonical=canonical,
+        targets=targets,
+        findings=findings,
+        errors=tuple(errors),
+    )
+
+
+def render_audit_report(report: AuditReport) -> PendingAuditReport:
+    timestamp = report.generated_at.isoformat().replace("+00:00", "Z")
+    lines = [
+        AUDIT_MARKER,
+        "# SDK drift audit",
+        "",
+        f"Head-to-head audit generated at `{timestamp}`.",
+        "",
+        "> Findings are advisory and never create downstream changes automatically.",
+        "",
+        "## Audited heads",
+        "",
+        "| Target | Repository | Commit | Health |",
+        "| --- | --- | --- | --- |",
+        _snapshot_row(report.canonical),
+        *(_snapshot_row(target) for target in report.targets),
+        "",
+        "## Findings",
+        "",
+    ]
+    if report.findings:
+        lines.extend(
+            [
+                "| Finding | Fingerprint | Affected | Clean | Likely origin |",
+                "| --- | --- | --- | --- | --- |",
+            ]
+        )
+        for finding in report.findings:
+            lines.append(
+                "| {id} | `{fingerprint}` | {affected} | {clean} | {origin} |".format(
+                    id=finding.id,
+                    fingerprint=_escape(finding.fingerprint),
+                    affected=", ".join(f"`{item}`" for item in finding.affected),
+                    clean=", ".join(f"`{item}`" for item in finding.clean) or "—",
+                    origin=_escape(finding.likely_origin),
+                )
+            )
+        for finding in report.findings:
+            lines.extend(
+                [
+                    "",
+                    f"### {finding.id} — `{finding.fingerprint}`",
+                    "",
+                    finding.summary,
+                    "",
+                    f"- Affected: {', '.join(f'`{item}`' for item in finding.affected)}",
+                    f"- Clean: {', '.join(f'`{item}`' for item in finding.clean) or 'none'}",
+                    f"- Canonical reference: `{finding.reference or 'conformance result'}`",
+                    f"- Likely origin: {finding.likely_origin}",
+                ]
+            )
+    else:
+        lines.append("No deterministic capability or conformance deltas detected.")
+
+    lines.extend(["", "## Audit health", ""])
+    if report.errors:
+        lines.extend(f"- {error}" for error in report.errors)
+    else:
+        lines.append("All configured SDK snapshots completed successfully.")
+    lines.extend(
+        [
+            "",
+            "This roll-up is updated in place. Individual SDK issues and propagation "
+            "remain explicit maintainer actions.",
+        ]
+    )
+    return PendingAuditReport(
+        title=AUDIT_TITLE,
+        body="\n".join(lines).rstrip() + "\n",
+        healthy=not report.errors,
+    )
+
+
+def deliver_audit_report(
+    client: GitHub, pending: PendingAuditReport
+) -> dict[str, object]:
+    existing = client.find_tracking_issue(AUDIT_MARKER)
+    if existing is None:
+        return client.create_issue(pending.title, pending.body)
+    return client.update_issue(
+        int(str(existing["number"])),
+        title=pending.title,
+        body=pending.body,
+    )
+
+
+def load_snapshots(directory: str | Path) -> tuple[AuditSnapshot, ...]:
+    snapshots = []
+    for path in sorted(Path(directory).glob("*.json")):
+        try:
+            snapshots.append(AuditSnapshot.model_validate_json(path.read_text()))
+        except (OSError, ValidationError) as exc:
+            raise AuditError(f"cannot read audit snapshot {path}: {exc}") from exc
+    targets = [snapshot.target for snapshot in snapshots]
+    if len(targets) != len(set(targets)):
+        raise AuditError("audit snapshots contain duplicate targets")
+    return tuple(snapshots)
+
+
+def read_json_object(path: str | Path) -> dict[str, object]:
+    try:
+        value = json.loads(Path(path).read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AuditError(f"cannot read JSON object {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AuditError(f"{path} must contain a JSON object")
+    return value
+
+
+def _component(value: str) -> str:
+    return re.sub(r"[^a-z0-9._-]+", "-", value.lower()).strip("-") or "unknown"
+
+
+def _likely_origin(affected: int, total: int) -> str:
+    if total > 1 and affected == total - 1:
+        return "likely canonical change that did not fan out"
+    if affected == 1:
+        return "likely SDK-local divergence"
+    return "shared downstream divergence"
+
+
+def _escape(value: str) -> str:
+    return value.replace("|", "\\|")
+
+
+def _snapshot_row(snapshot: AuditSnapshot) -> str:
+    link = f"https://github.com/{snapshot.repo}/commit/{snapshot.sha}"
+    health = "Incomplete" if snapshot.errors else "Complete"
+    return (
+        f"| `{snapshot.target}` | `{snapshot.repo}` | "
+        f"[`{snapshot.sha[:12]}`]({link}) | {health} |"
+    )

--- a/agricola/cli.py
+++ b/agricola/cli.py
@@ -8,6 +8,16 @@ from pathlib import Path
 
 from pydantic import TypeAdapter, ValidationError
 
+from .audit import (
+    AuditError,
+    audit_matrix,
+    build_audit_report,
+    deliver_audit_report,
+    load_snapshots,
+    read_json_object,
+    render_audit_report,
+    snapshot_from_conformance,
+)
 from .commands import parse_commands, require_maintainer
 from .executor import (
     VerificationError,
@@ -16,11 +26,12 @@ from .executor import (
     verify,
 )
 from .github import GitHubClient
-from .ledger import CursorStore, DecisionLedger, LedgerError
+from .ledger import AuditStore, CursorStore, DecisionLedger, LedgerError
 from .manifest import ManifestError, load_manifest, print_schemas
 from .models import (
     PendingIssueUpdate,
     PendingReply,
+    PendingAuditReport,
     PropagationOutcome,
     PropagationRequest,
 )
@@ -96,6 +107,39 @@ def parser() -> argparse.ArgumentParser:
         help="directory for issue updates delivered after ledger persistence",
     )
 
+    matrix = subcommands.add_parser(
+        "audit-matrix", help="render the manifest audit matrix"
+    )
+    matrix.add_argument(
+        "--adapters",
+        default="conformance/adapters",
+        help="conformance adapter directory",
+    )
+
+    snapshot = subcommands.add_parser(
+        "audit-snapshot", help="normalize one head conformance result"
+    )
+    snapshot.add_argument("--target", required=True)
+    snapshot.add_argument("--repo", required=True)
+    snapshot.add_argument("--sha", required=True)
+    snapshot.add_argument("--adapter-manifest", required=True)
+    snapshot.add_argument("--results", required=True)
+
+    builder = subcommands.add_parser(
+        "build-audit", help="cluster snapshots and render the audit roll-up"
+    )
+    builder.add_argument("snapshots", help="directory containing audit snapshots")
+    builder.add_argument("--report-file", required=True)
+
+    audit_delivery = subcommands.add_parser(
+        "deliver-audit", help="create or update the audit roll-up issue"
+    )
+    audit_delivery.add_argument("report_file")
+    audit_delivery.add_argument(
+        "--control-repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "tempoxyz/mpp-tools"),
+    )
+
     verifier = subcommands.add_parser(
         "verify-propagation", help="run manifest verification for generated changes"
     )
@@ -143,6 +187,42 @@ def main(argv: list[str] | None = None) -> int:
             body=update.body,
         )
         print(json.dumps({"updated": True, "issue_number": update.issue_number}))
+        return 0
+    if args.command == "deliver-audit":
+        try:
+            pending = PendingAuditReport.model_validate_json(
+                Path(args.report_file).read_text()
+            )
+            issue = deliver_audit_report(
+                GitHubClient(args.control_repo),
+                pending,
+            )
+        except (AuditError, OSError, ValidationError) as exc:
+            print(f"audit report error: {exc}", file=sys.stderr)
+            return 2
+        print(
+            json.dumps(
+                {
+                    "delivered": True,
+                    "issue_number": issue.get("number"),
+                    "url": issue.get("html_url"),
+                }
+            )
+        )
+        return 0
+    if args.command == "audit-snapshot":
+        try:
+            snapshot = snapshot_from_conformance(
+                target=args.target,
+                repo=args.repo,
+                sha=args.sha,
+                adapter_manifest=read_json_object(args.adapter_manifest),
+                results=read_json_object(args.results),
+            )
+        except (AuditError, ValidationError) as exc:
+            print(f"audit snapshot error: {exc}", file=sys.stderr)
+            return 2
+        print(snapshot.model_dump_json(indent=2))
         return 0
     if args.command == "record-propagations":
         result_paths = tuple(sorted(Path(args.results).glob("*.json")))
@@ -210,6 +290,38 @@ def main(argv: list[str] | None = None) -> int:
         print(f"manifest error: {exc}", file=sys.stderr)
         return 2
     ledger = DecisionLedger(args.ledger)
+
+    if args.command == "audit-matrix":
+        try:
+            matrix = audit_matrix(manifest, args.adapters)
+        except AuditError as exc:
+            print(f"audit matrix error: {exc}", file=sys.stderr)
+            return 2
+        print(json.dumps(matrix, indent=2))
+        return 0
+    if args.command == "build-audit":
+        try:
+            report = build_audit_report(
+                manifest,
+                load_snapshots(args.snapshots),
+                AuditStore(args.ledger),
+            )
+            pending = render_audit_report(report)
+            Path(args.report_file).write_text(pending.model_dump_json(indent=2) + "\n")
+        except (AuditError, LedgerError, OSError, ValidationError) as exc:
+            print(f"audit report error: {exc}", file=sys.stderr)
+            return 2
+        print(
+            json.dumps(
+                {
+                    "findings": len(report.findings),
+                    "errors": len(report.errors),
+                    "healthy": pending.healthy,
+                },
+                indent=2,
+            )
+        )
+        return 0
 
     if args.command == "validate":
         try:

--- a/agricola/ledger.py
+++ b/agricola/ledger.py
@@ -8,9 +8,18 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
-from .models import CanonicalChange, Cursor, Decision, LedgerEntry, Source
+from .models import (
+    AuditFindingRecord,
+    AuditRegistry,
+    CanonicalChange,
+    Cursor,
+    Decision,
+    LedgerEntry,
+    Source,
+)
 
 CURSOR_FILENAME = "cursor.json"
+AUDIT_FILENAME = "audit.json"
 
 
 class LedgerError(ValueError):
@@ -38,7 +47,7 @@ class DecisionLedger:
         paths = tuple(
             path
             for path in sorted(self.root.glob("*.json"))
-            if path.name != CURSOR_FILENAME
+            if path.name not in {AUDIT_FILENAME, CURSOR_FILENAME}
         )
         for path in paths:
             try:
@@ -46,6 +55,7 @@ class DecisionLedger:
             except (OSError, ValidationError) as exc:
                 raise LedgerError(f"cannot read ledger entry {path}: {exc}") from exc
         CursorStore(self.root).validate()
+        AuditStore(self.root).validate()
         return paths
 
     def append(self, change: CanonicalChange, decision: Decision) -> bool:
@@ -156,6 +166,57 @@ class CursorStore:
     def save(self, cursor: Cursor) -> None:
         content = cursor.model_dump_json(indent=2) + "\n"
         _atomic_write(self.path, content)
+
+
+class AuditStore:
+    def __init__(self, root: str | Path = "ledger") -> None:
+        self.path = Path(root) / AUDIT_FILENAME
+
+    def load(self) -> AuditRegistry:
+        if not self.path.exists():
+            return AuditRegistry()
+        try:
+            return AuditRegistry.model_validate_json(self.path.read_text())
+        except (OSError, ValidationError) as exc:
+            raise LedgerError(f"cannot read audit registry {self.path}: {exc}") from exc
+
+    def validate(self) -> None:
+        if self.path.exists():
+            self.load()
+
+    def assign(self, fingerprints: Iterable[str], at: datetime) -> dict[str, str]:
+        registry = self.load()
+        records = list(registry.findings)
+        by_fingerprint = {record.fingerprint: record.id for record in records}
+        year = at.astimezone(UTC).year
+        sequence = max(
+            (
+                int(record.id.rsplit("-", 1)[-1])
+                for record in records
+                if record.id.startswith(f"AGR-{year}-")
+            ),
+            default=0,
+        )
+        for fingerprint in sorted(set(fingerprints)):
+            if fingerprint in by_fingerprint:
+                continue
+            sequence += 1
+            finding_id = f"AGR-{year}-{sequence:03d}"
+            records.append(
+                AuditFindingRecord(
+                    id=finding_id,
+                    fingerprint=fingerprint,
+                    first_seen=at,
+                )
+            )
+            by_fingerprint[fingerprint] = finding_id
+        updated = AuditRegistry(findings=tuple(records))
+        if updated != registry:
+            _atomic_write(
+                self.path,
+                updated.model_dump_json(indent=2) + "\n",
+            )
+        return by_fingerprint
 
 
 def _atomic_write(path: Path, content: str) -> None:

--- a/agricola/manifest.py
+++ b/agricola/manifest.py
@@ -9,7 +9,7 @@ from yaml import resolver
 from yaml.constructor import ConstructorError
 from yaml.nodes import MappingNode
 
-from .models import Cursor, LedgerEntry, Manifest
+from .models import AuditRegistry, Cursor, LedgerEntry, Manifest
 
 
 class ManifestError(ValueError):
@@ -65,6 +65,7 @@ def generated_schemas() -> dict[str, dict[str, object]]:
         "manifest": Manifest.model_json_schema(),
         "ledger": LedgerEntry.model_json_schema(),
         "cursor": Cursor.model_json_schema(),
+        "audit": AuditRegistry.model_json_schema(),
     }
 
 

--- a/agricola/models.py
+++ b/agricola/models.py
@@ -319,6 +319,93 @@ class PendingIssueUpdate(FrozenModel):
     body: NonEmpty
 
 
+class AuditCheckStatus(StrEnum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+
+
+class AuditObservation(FrozenModel):
+    fingerprint: NonEmpty
+    status: AuditCheckStatus
+    summary: NonEmpty
+    reference: str | None = None
+
+
+class AuditSnapshot(FrozenModel):
+    target: NonEmpty
+    repo: RepoName
+    sha: Sha
+    capabilities: frozenset[NonEmpty]
+    observations: tuple[AuditObservation, ...]
+    errors: tuple[NonEmpty, ...] = ()
+
+    @model_validator(mode="after")
+    def require_unique_observations(self) -> AuditSnapshot:
+        fingerprints = [item.fingerprint for item in self.observations]
+        if len(fingerprints) != len(set(fingerprints)):
+            raise ValueError("audit observation fingerprints must be unique")
+        return self
+
+
+class AuditFindingRecord(FrozenModel):
+    id: FindingId
+    fingerprint: NonEmpty
+    first_seen: datetime
+
+    @field_validator("first_seen")
+    @classmethod
+    def require_aware_timestamp(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamp must include a timezone")
+        return value.astimezone(UTC)
+
+
+class AuditRegistry(FrozenModel):
+    version: Literal[1] = 1
+    findings: tuple[AuditFindingRecord, ...] = ()
+
+    @model_validator(mode="after")
+    def require_unique_findings(self) -> AuditRegistry:
+        ids = [finding.id for finding in self.findings]
+        fingerprints = [finding.fingerprint for finding in self.findings]
+        if len(ids) != len(set(ids)):
+            raise ValueError("audit finding IDs must be unique")
+        if len(fingerprints) != len(set(fingerprints)):
+            raise ValueError("audit finding fingerprints must be unique")
+        return self
+
+
+class AuditFinding(FrozenModel):
+    id: FindingId
+    fingerprint: NonEmpty
+    summary: NonEmpty
+    reference: str | None = None
+    affected: tuple[NonEmpty, ...] = Field(min_length=1)
+    clean: tuple[NonEmpty, ...] = ()
+    likely_origin: NonEmpty
+
+
+class AuditReport(FrozenModel):
+    generated_at: datetime
+    canonical: AuditSnapshot
+    targets: tuple[AuditSnapshot, ...]
+    findings: tuple[AuditFinding, ...]
+    errors: tuple[NonEmpty, ...] = ()
+
+    @field_validator("generated_at")
+    @classmethod
+    def require_aware_timestamp(cls, value: datetime) -> datetime:
+        if value.tzinfo is None:
+            raise ValueError("timestamp must include a timezone")
+        return value.astimezone(UTC)
+
+
+class PendingAuditReport(FrozenModel):
+    title: NonEmpty
+    body: NonEmpty
+    healthy: bool
+
+
 class Cursor(FrozenModel):
     merged_at: datetime
 

--- a/agricola/tests/test_audit.py
+++ b/agricola/tests/test_audit.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+from agricola.audit import (
+    AUDIT_MARKER,
+    analyze_deltas,
+    audit_matrix,
+    build_audit_report,
+    deliver_audit_report,
+    render_audit_report,
+    snapshot_from_conformance,
+)
+from agricola.ledger import AuditStore
+from agricola.models import (
+    AuditCheckStatus,
+    AuditObservation,
+    AuditSnapshot,
+)
+from agricola.tests.helpers import manifest
+from agricola.tests.test_service import FakeGitHub
+
+
+def observation(
+    fingerprint: str,
+    status: AuditCheckStatus = AuditCheckStatus.SUCCESS,
+) -> AuditObservation:
+    return AuditObservation(
+        fingerprint=fingerprint,
+        status=status,
+        summary=f"Check {fingerprint}",
+        reference="MPP-1",
+    )
+
+
+def snapshot(
+    target: str,
+    *,
+    capabilities: tuple[str, ...] = ("challenge.parse", "receipt.parse"),
+    observations: tuple[AuditObservation, ...] = (),
+    errors: tuple[str, ...] = (),
+) -> AuditSnapshot:
+    repos = {
+        "typescript": "wevm/mppx",
+        "go": "tempoxyz/mpp-go",
+        "rust": "tempoxyz/mpp-rs",
+        "ruby": "stripe/mpp-rb",
+    }
+    return AuditSnapshot(
+        target=target,
+        repo=repos[target],
+        sha=f"{target}1234567",
+        capabilities=frozenset(capabilities),
+        observations=observations,
+        errors=errors,
+    )
+
+
+class AuditTests(unittest.TestCase):
+    def test_normalizes_conformance_results(self) -> None:
+        result = snapshot_from_conformance(
+            target="rust",
+            repo="tempoxyz/mpp-rs",
+            sha="abc1234567",
+            adapter_manifest={"capabilities": ["challenge.parse"]},
+            results={
+                "checks": [
+                    {
+                        "name": "rust challenge",
+                        "description": "Parses challenge",
+                        "status": "FAILURE",
+                        "specReferences": [{"id": "MPP-1"}],
+                        "details": {
+                            "vector": "www-authenticate",
+                            "scenario": "basic challenge",
+                            "testType": "parse",
+                        },
+                    },
+                    {
+                        "name": "build",
+                        "description": "Adapter builds",
+                        "status": "FAILURE",
+                        "details": {
+                            "vector": "adapter",
+                            "scenario": "build",
+                            "testType": "build",
+                        },
+                    },
+                ]
+            },
+        )
+
+        self.assertEqual(result.capabilities, {"challenge.parse"})
+        self.assertEqual(
+            result.observations[0].fingerprint,
+            "vector:www-authenticate/basic-challenge/parse",
+        )
+        self.assertEqual(result.errors, ("rust: Adapter builds",))
+
+    def test_clusters_capability_and_vector_deltas(self) -> None:
+        check = "vector:www-authenticate/basic/parse"
+        canonical = snapshot(
+            "typescript",
+            observations=(observation(check),),
+        )
+        go = snapshot(
+            "go",
+            capabilities=("challenge.parse",),
+            observations=(observation(check, AuditCheckStatus.FAILURE),),
+        )
+        rust = snapshot("rust", observations=(observation(check),))
+
+        findings, errors = analyze_deltas(canonical, (go, rust))
+
+        self.assertFalse(errors)
+        by_fingerprint = {finding.fingerprint: finding for finding in findings}
+        self.assertEqual(
+            by_fingerprint["capability:receipt.parse"].affected,
+            ("go",),
+        )
+        self.assertEqual(by_fingerprint[check].affected, ("go",))
+        self.assertEqual(by_fingerprint[check].clean, ("rust",))
+        self.assertEqual(
+            by_fingerprint[check].likely_origin,
+            "likely canonical change that did not fan out",
+        )
+
+    def test_vector_clean_requires_an_explicit_success(self) -> None:
+        check = "vector:www-authenticate/basic/parse"
+        canonical = snapshot(
+            "typescript",
+            observations=(observation(check),),
+        )
+        go = snapshot(
+            "go",
+            observations=(observation(check, AuditCheckStatus.FAILURE),),
+        )
+        rust = snapshot("rust", observations=(observation(check),))
+        ruby = snapshot("ruby")
+
+        findings, _ = analyze_deltas(canonical, (go, rust, ruby))
+
+        finding = next(item for item in findings if item.fingerprint == check)
+        self.assertEqual(finding.clean, ("rust",))
+        self.assertEqual(finding.summary, "Check " + check)
+
+    def test_assigns_stable_ids_and_renders_one_rollup(self) -> None:
+        check = "vector:www-authenticate/basic/parse"
+        canonical = snapshot("typescript", observations=(observation(check),))
+        go = snapshot(
+            "go",
+            observations=(observation(check, AuditCheckStatus.FAILURE),),
+        )
+        rust = snapshot("rust", observations=(observation(check),))
+        ruby = snapshot("ruby", observations=(observation(check),))
+        at = datetime(2026, 8, 8, 18, 0, tzinfo=UTC)
+
+        with tempfile.TemporaryDirectory() as directory:
+            store = AuditStore(directory)
+            first = build_audit_report(
+                manifest(), (canonical, go, rust, ruby), store, at=at
+            )
+            second = build_audit_report(
+                manifest(), (canonical, go, rust, ruby), store, at=at
+            )
+
+            self.assertEqual(first.findings[0].id, "AGR-2026-001")
+            self.assertEqual(second.findings[0].id, "AGR-2026-001")
+            pending = render_audit_report(first)
+            self.assertTrue(pending.healthy)
+            self.assertIn(AUDIT_MARKER, pending.body)
+            self.assertIn("AGR-2026-001", pending.body)
+            self.assertIn("`go`", pending.body)
+
+    def test_missing_snapshot_marks_report_incomplete(self) -> None:
+        canonical = snapshot("typescript")
+        with tempfile.TemporaryDirectory() as directory:
+            report = build_audit_report(manifest(), (canonical,), AuditStore(directory))
+
+        pending = render_audit_report(report)
+        self.assertFalse(pending.healthy)
+        self.assertIn("go: audit snapshot is missing", pending.body)
+
+    def test_matrix_requires_every_manifest_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for target in manifest().sdks:
+                path = root / target
+                path.mkdir()
+                (path / "adapter.json").touch()
+
+            result = audit_matrix(manifest(), root)
+
+        self.assertEqual(
+            [item["target"] for item in result["include"]],
+            ["go", "rust", "ruby"],
+        )
+
+    def test_delivery_updates_existing_rollup(self) -> None:
+        client = FakeGitHub()
+        client.tracking = {"number": 42, "body": AUDIT_MARKER}
+        pending = render_audit_report(AuditReportFixture.complete())
+
+        deliver_audit_report(client, pending)
+
+        self.assertEqual(client.updated[0][0], 42)
+        self.assertIn(AUDIT_MARKER, client.updated[0][2] or "")
+
+
+class AuditReportFixture:
+    @staticmethod
+    def complete():
+        with tempfile.TemporaryDirectory() as directory:
+            return build_audit_report(
+                manifest(),
+                (
+                    snapshot("typescript"),
+                    snapshot("go"),
+                    snapshot("rust"),
+                    snapshot("ruby"),
+                ),
+                AuditStore(directory),
+                at=datetime(2026, 8, 8, 18, 0, tzinfo=UTC),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agricola/tests/test_ledger.py
+++ b/agricola/tests/test_ledger.py
@@ -5,7 +5,7 @@ import tempfile
 import unittest
 from datetime import UTC, datetime, timedelta
 
-from agricola.ledger import CursorStore, DecisionLedger, LedgerError
+from agricola.ledger import AuditStore, CursorStore, DecisionLedger, LedgerError
 from agricola.models import Cursor, DecisionKind, SkipDecision
 from agricola.tests.helpers import change
 
@@ -125,6 +125,17 @@ class CursorStoreTests(unittest.TestCase):
             store.path.parent.mkdir(parents=True, exist_ok=True)
             store.path.write_text('{"merged_at": "yesterday"}\n')
             with self.assertRaisesRegex(LedgerError, "cannot read cursor"):
+                DecisionLedger(directory).validate_all()
+
+
+class AuditStoreTests(unittest.TestCase):
+    def test_validation_rejects_malformed_registry(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = AuditStore(directory)
+            store.path.parent.mkdir(parents=True, exist_ok=True)
+            store.path.write_text('{"version": 2}\n')
+
+            with self.assertRaisesRegex(LedgerError, "cannot read audit registry"):
                 DecisionLedger(directory).validate_all()
 
 

--- a/agricola/tests/test_manifest.py
+++ b/agricola/tests/test_manifest.py
@@ -99,7 +99,7 @@ sdks:
 
     def test_generated_schemas_cover_persisted_models(self) -> None:
         schemas = generated_schemas()
-        self.assertEqual(set(schemas), {"manifest", "ledger", "cursor"})
+        self.assertEqual(set(schemas), {"manifest", "ledger", "cursor", "audit"})
         self.assertFalse(schemas["manifest"]["additionalProperties"])
         ledger_definitions = schemas["ledger"]["$defs"]
         self.assertIsInstance(ledger_definitions, dict)

--- a/conformance/scripts/select_ci_adapters.py
+++ b/conformance/scripts/select_ci_adapters.py
@@ -34,7 +34,7 @@ ADAPTER_PATTERNS = {
 
 AGRICOLA_PATTERNS = [
     ".github/agricola/**",
-    ".github/workflows/agricola.yml",
+    ".github/workflows/agricola*.yml",
     "agricola/**",
     "docs/**",
     "ledger/**",

--- a/conformance/scripts/test_select_ci_adapters.py
+++ b/conformance/scripts/test_select_ci_adapters.py
@@ -13,6 +13,7 @@ class SelectAdaptersTests(unittest.TestCase):
                 "pull_request",
                 [
                     ".github/agricola/propagate.md",
+                    ".github/workflows/agricola-audit.yml",
                     ".github/workflows/agricola.yml",
                     "agricola/service.py",
                     "agricola/tests/test_service.py",

--- a/docs/agricola-actions.md
+++ b/docs/agricola-actions.md
@@ -1,6 +1,6 @@
 # Agricola Actions setup
 
-Agricola runs from [`.github/workflows/agricola.yml`](../.github/workflows/agricola.yml). The repository-scoped `GITHUB_TOKEN` manages control-plane issues and state; a GitHub App supplies short-lived cross-repository tokens; the official OpenAI action generates downstream patches.
+Agricola propagation runs from [`.github/workflows/agricola.yml`](../.github/workflows/agricola.yml), and the head-to-head SDK audit runs from [`.github/workflows/agricola-audit.yml`](../.github/workflows/agricola-audit.yml). The repository-scoped `GITHUB_TOKEN` manages control-plane issues and state; a GitHub App supplies short-lived cross-repository tokens; the official OpenAI action generates downstream patches.
 
 ## Triggers
 
@@ -9,6 +9,8 @@ Agricola runs from [`.github/workflows/agricola.yml`](../.github/workflows/agric
 | Ten-minute schedule | Poll merged `wevm/mppx` pull requests. GitHub may delay scheduled jobs. |
 | `workflow_dispatch` | Run the poller manually. |
 | New `issue_comment` containing `@agricola` | Handle a tracking-issue command. `@agricola` must be the first token on a line. |
+
+The audit workflow runs every Monday at 09:00 UTC and supports `workflow_dispatch`. It checks out the current default-branch head of `mppx` and every manifest SDK, runs the shared vectors, compares conformance-adapter capabilities, clusters matching fingerprints, and updates one roll-up issue. It is read-only outside `mpp-tools` and never invokes downstream publication.
 
 One concurrency group serializes all triggers. Runs execute trusted code from the current default branch. Ledger state is restored from `agricola/state`; the changelog-style updater creates or updates at most one state pull request. Merge it to checkpoint state on the default branch. Do not close or edit it manually. Code from the state branch is never executed.
 
@@ -71,6 +73,7 @@ Downstream code never runs in a job containing downstream write credentials. Gen
 5. Enable workflow write access and pull-request creation.
 6. Run the workflow manually and confirm the poll succeeds and the state pull request contains `ledger/cursor.json`.
 7. On a tracking issue, run `@agricola propagate <target>` and confirm generation, verification, a downstream draft pull request, and a recorded ledger decision.
+8. Run the SDK audit manually and confirm one `[Agricola] SDK drift audit` issue contains every target and exact audited commit.
 
 The initial cursor starts fifteen minutes in the past. Because each poll replays a one-hour overlap, the first API read covers approximately the previous 75 minutes. To backfill a different window, update the state pull request with a reviewed `ledger/cursor.json` containing a timezone-aware ISO 8601 `merged_at`; polling begins one hour before it.
 
@@ -89,6 +92,9 @@ Run from the command line:
 ```bash
 gh workflow run agricola.yml --repo tempoxyz/mpp-tools --ref main
 gh run list --repo tempoxyz/mpp-tools --workflow agricola.yml --limit 1
+
+gh workflow run agricola-audit.yml --repo tempoxyz/mpp-tools --ref main
+gh run list --repo tempoxyz/mpp-tools --workflow agricola-audit.yml --limit 1
 ```
 
 The Actions page also exposes **Run workflow** through `workflow_dispatch`.
@@ -102,3 +108,4 @@ The Actions page also exposes **Run workflow** through `workflow_dispatch`.
 - Publication fails: confirm the App installation covers the target and grants contents/pull-request write access. Reopen a closed stable pull request before retrying.
 - A command has no reply: inspect state persistence. Replies are intentionally skipped after failed ledger updates.
 - The state pull request is not updated: confirm workflow write access and permission to create pull requests.
+- An audit target is incomplete: inspect its SDK-tagged audit job. Missing snapshots are reported in the roll-up and make the workflow fail after the issue is updated.


### PR DESCRIPTION
## Motivation

Make SDK drift visible through one recurring, deterministic audit against canonical mppx behavior.

## Summary

- add weekly and manually dispatched head-to-head SDK audit workflow
- normalize conformance results and capability matrices into stable fingerprints
- cluster affected and clean SDKs under persistent AGR finding IDs
- update one audit roll-up issue and persist its finding registry through Agricola state
- document manual operation, recovery, and CI behavior

## Key design considerations

- mppx remains the sole canonical reference; downstream SDKs are never compared directly
- clean status requires an explicit successful observation
- notification-only SDKs are audited read-only
- findings cannot automatically create downstream issues, branches, or pull requests