### PR TITLE
fix(agricola): provision uv and pin Sol model

### DIFF
--- a/.github/workflows/agricola-audit.yml
+++ b/.github/workflows/agricola-audit.yml
@@ -218,6 +218,7 @@ jobs:
           output-schema-file: .audit/semantic-output.schema.json
           permission-profile: ":read-only"
           safety-strategy: drop-sudo
+          model: gpt-5.6-sol
           codex-args: '["--ephemeral"]'
 
       - name: Build SDK snapshot

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -180,6 +180,7 @@ jobs:
           output-file: .agricola/codex-output.md
           permission-profile: ":workspace"
           safety-strategy: drop-sudo
+          model: gpt-5.6-sol
           codex-args: '["--ephemeral"]'
 
       - name: Capture generated patch
@@ -272,6 +273,12 @@ jobs:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: .agricola/control/pyproject.toml
+
+      - name: Setup uv
+        if: steps.patch.outputs.has-changes == 'true'
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        with:
+          version: "0.9.26"
 
       - name: Run manifest verification
         if: steps.patch.outputs.has-changes == 'true'

--- a/docs/agricola-actions.md
+++ b/docs/agricola-actions.md
@@ -2,6 +2,8 @@
 
 Agricola propagation runs from [`.github/workflows/agricola.yml`](../.github/workflows/agricola.yml), and the head-to-head SDK audit runs from [`.github/workflows/agricola-audit.yml`](../.github/workflows/agricola-audit.yml). The repository-scoped `GITHUB_TOKEN` manages control-plane issues and state; a GitHub App supplies short-lived cross-repository tokens; the official OpenAI action generates downstream patches and performs read-only semantic audits.
 
+Both semantic analysis and downstream generation explicitly use `gpt-5.6-sol`. Downstream verification installs the pinned `uv` version before running manifest commands such as `uv run pytest`.
+
 ## Triggers
 
 | Trigger | Behavior |


### PR DESCRIPTION
## Motivation

Allow Python remediation verification to run its declared `uv` command and make the model used by both Agricola agent workflows explicit.

## Summary

- installs pinned `uv 0.9.26` before downstream manifest verification
- pins semantic SDK analysis to `gpt-5.6-sol`
- pins downstream remediation generation to `gpt-5.6-sol`
- documents the verification and model configuration

## Key design considerations

- reuses the repository’s existing `uv` version
- keeps tool setup in the secretless verification job
- uses the Codex action’s dedicated model input