### PR TITLE
fix(flow-runner): fail cases where adapter skips a required capability

### DIFF
--- a/conformance/scripts/flow_runner.py
+++ b/conformance/scripts/flow_runner.py
@@ -684,7 +684,19 @@ def compare_results(
             continue
         golden = expected_map[name]
         if entry.get("outcome", {}).get("skipped") and not golden.get("outcome", {}).get("skipped"):
-            results.append(RunResult(adapter=adapter, name=str(name), passed=True))
+            # The golden reference ran this case for real; the adapter skipped it
+            # because it lacks a capability. That capability is only ever missing
+            # here for `http.payment_request`, which HARNESS_SPEC.md documents as
+            # "Required for flow conformance" -- so this is a real conformance gap,
+            # not an optional feature the adapter is allowed to opt out of.
+            requires = entry.get("outcome", {}).get("requires")
+            results.append(RunResult(
+                adapter=adapter,
+                name=str(name),
+                passed=False,
+                error=f"adapter skipped a case the golden reference did not skip "
+                f"(missing required capability: {requires})",
+            ))
             unmatched.discard(name)
             continue
         diff = compute_diff(normalize_result(golden), normalize_result(entry))

--- a/conformance/scripts/test_flow_runner.py
+++ b/conformance/scripts/test_flow_runner.py
@@ -7,7 +7,7 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
-from flow_runner import main, perform_request
+from flow_runner import compare_results, main, perform_request
 
 
 class PerformRequestTests(unittest.TestCase):
@@ -28,6 +28,47 @@ class PerformRequestTests(unittest.TestCase):
                 request = urlopen.call_args.args[0]
                 self.assertEqual(request.data, b'{"amount":"1"}')
                 self.assertEqual(request.get_header("Content-type"), "application/json")
+
+
+class CompareResultsCapabilitySkipTests(unittest.TestCase):
+    def test_skipping_a_required_capability_fails_not_passes(self) -> None:
+        # HARNESS_SPEC.md documents http.payment_request as "Required for flow
+        # conformance". An adapter that skips a case because it lacks that
+        # capability has a real conformance gap and must not be marked passed,
+        # even though the golden reference ran the case for real.
+        golden = [
+            {
+                "name": "plain_payment_request",
+                "outcome": {"ok": True, "status": 200},
+            }
+        ]
+        actual = [
+            {
+                "name": "plain_payment_request",
+                "outcome": {
+                    "ok": True,
+                    "status": 0,
+                    "skipped": True,
+                    "requires": "http.payment_request",
+                },
+            }
+        ]
+
+        results = compare_results(golden, actual, "broken-adapter")
+
+        self.assertEqual(len(results), 1)
+        self.assertFalse(results[0].passed)
+        self.assertIn("http.payment_request", results[0].error or "")
+
+    def test_both_golden_and_actual_skipped_is_unaffected(self) -> None:
+        outcome = {"ok": True, "status": 0, "skipped": True, "requires": "http.payment_request"}
+        golden = [{"name": "plain_payment_request", "outcome": outcome}]
+        actual = [{"name": "plain_payment_request", "outcome": dict(outcome)}]
+
+        results = compare_results(golden, actual, "adapter")
+
+        self.assertEqual(len(results), 1)
+        self.assertTrue(results[0].passed)
 
 
 class FlowRunnerOutputTests(unittest.TestCase):


### PR DESCRIPTION
Closes #119

## Problem

`compare_results()` in `conformance/scripts/flow_runner.py` marked a `client_flow` case `passed=True` whenever the adapter skipped it due to a missing capability, as long as the golden reference did not skip that same case. `skipped_flow()` is only ever produced for one capability: `http.payment_request`, which `HARNESS_SPEC.md` documents as "Required for flow conformance" (not optional). So an adapter that never implements this required capability got a free pass on all 3 `client_flow` cases instead of the failure a missing required capability should produce.

This is not hypothetical: #93 (Agricola audit finding AGR-2026-001) independently found the go, java, python, ruby, and rust SDKs all missing `http.payment_request`. This runner's own flow conformance suite should have caught that directly.

## Fix

The asymmetric-skip branch (`actual` skipped, `golden` not skipped) now records `passed=False` with an error naming the missing capability, instead of `passed=True`. The case where both `golden` and `actual` are skipped is unaffected -- that's a legitimate agreement, not a gap.

## Tests

Added `CompareResultsCapabilitySkipTests` in `test_flow_runner.py` covering both the fixed asymmetric case and confirming the symmetric (both-skipped) case still passes. Full suite (`uv run --locked python -m unittest discover -s scripts -p "test_*.py"`) passes: 71/71.
