### PR TITLE
fix(adapters): use the hardened base64url decoder in credential_to_dict

### DIFF
--- a/conformance/adapters/python/adapter.py
+++ b/conformance/adapters/python/adapter.py
@@ -119,10 +119,12 @@ def challenge_to_dict(challenge: Challenge) -> dict:
 def credential_to_dict(credential: Credential) -> dict:
     """Convert a Credential to a JSON-serializable dict."""
     challenge = credential.challenge
-    # Decode the base64url request string back to an object
-    request_decoded = json.loads(
-        base64.urlsafe_b64decode(challenge.request + "=" * (-len(challenge.request) % 4))
-    )
+    # Decode the base64url request string back to an object. Use the
+    # hardened base64url_decode() here too: raw urlsafe_b64decode()
+    # silently drops out-of-alphabet characters instead of rejecting
+    # them, which would let a malformed embedded `request` field pass
+    # through this adapter while every other adapter rejects it.
+    request_decoded = json.loads(base64url_decode(challenge.request))
 
     challenge_dict = {
         "id": challenge.id,


### PR DESCRIPTION
## Summary

`conformance/adapters/python/adapter.py`'s `base64url_decode()` helper
was hardened in #56 to reject out-of-alphabet characters instead of
silently dropping them, specifically because "silently dropping
out-of-alphabet characters would accept wire values every other
adapter refuses."

`credential_to_dict()` — the function backing the `parse-authorization`
command — never adopted that helper. It re-decodes the credential's
nested `challenge.request` field with a raw, hand-rolled call to
`base64.urlsafe_b64decode()`, which does not validate the alphabet
by default and can silently accept malformed input that the file's
own hardened decoder (right above it) is specifically designed to
reject.

This patch makes `credential_to_dict()` reuse `base64url_decode()`
instead of duplicating (and under-hardening) the decode logic.

## Reproduction

```python
>>> import base64
>>> base64.urlsafe_b64decode('aGVsbG8h!===')
b'hello!'   # no exception — the '!' is silently discarded
```

Confirmed end-to-end against the real `parse-authorization` command
with `pympp==0.9.1` (the pinned version): a syntactically valid
`Authorization: Payment ...` credential whose *outer* envelope is
well-formed base64url/JSON, but whose *embedded* `challenge.request`
string contains one out-of-alphabet character, is currently accepted
(`"success": true`) by this adapter. After the fix it is correctly
rejected (`"success": false, "error_type": "parse_error"`).

## Scope note

While testing this, I found the same input is *also* silently
accepted by the pinned golden `mppx` TypeScript adapter (the
conformance oracle), so I did not add a cross-adapter conformance
vector for it here — that would currently fail against the oracle
itself and isn't a decision this PR should make unilaterally. I've
opened a separate issue to get maintainer guidance on that broader
question, consistent with how #50 was handled. This PR is scoped to
the narrow, uncontroversial fix: making the Python adapter consistent
with its own documented invariant.

## Testing

cd conformance
python scripts/vector_runner.py --adapter python

126/126 scenarios pass (no regressions).

## Checklist (per CONTRIBUTING.md)

- [x] Change is focused and follows existing patterns (reuses the
      existing helper rather than introducing a new one).
- [ ] `make all` — not run in full (no Go/Ruby/Java toolchains
      available in my environment); ran the Python vector suite
      directly instead. Happy to re-run if useful.
- [x] No secrets, credentials, local paths, or generated artifacts
      committed.

---

## Open question for maintainers

While testing this, I found the same underlying leniency also
affects the pinned golden `mppx` TypeScript adapter — the conformance
oracle. A credential whose outer envelope is valid base64url/JSON but
whose embedded `challenge.request` field contains a single
out-of-alphabet character is currently accepted, not rejected, by
mppx too. I didn't add a cross-adapter conformance vector for this in
this PR since it would fail against the oracle itself.

Before I prepare that follow-up (vector + possible upstream `mppx`
fix), I'd like guidance similar to what was asked in #50:

1. Should `mppx` reject this input? If so, the fix belongs upstream
   in `mppx`, and the conformance vector should be added once the
   golden adapter passes it.
2. Or is loose parsing of the nested `request` field intentional? If
   so, worth documenting explicitly.

Happy to prepare the vector + adapter changes once the intended
contract is clear.