### PR TITLE
fix(agricola): exclude devnet-only Rust tests

### DIFF
--- a/agricola/README.md
+++ b/agricola/README.md
@@ -65,7 +65,7 @@ No checked-in schema copies need synchronization.
 - `automation`: `pr` for managed propagation or `notify` for external targets;
 - repository, owners, changelog convention, and verification commands for each target.
 
-Set `changelog: none` when the target repository creates release-note fragments automatically; Agricola then leaves that repository-owned workflow in control.
+Set `changelog: fragment` when the target repository requires release-note fragments, or `changelog: none` when release notes are automatic or unnecessary.
 
 Every `automation: pr` target must declare at least one verification command. The executor runs these commands after generation and before it receives downstream write credentials.
 

--- a/agricola/models.py
+++ b/agricola/models.py
@@ -52,6 +52,7 @@ class Automation(StrEnum):
 
 class Changelog(StrEnum):
     KEEP_A_CHANGELOG = "keep-a-changelog"
+    FRAGMENT = "fragment"
     NONE = "none"
 
 

--- a/agricola/tests/test_manifest.py
+++ b/agricola/tests/test_manifest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import cast
 
 from agricola.manifest import ManifestError, generated_schemas, load_manifest
-from agricola.models import Automation
+from agricola.models import Automation, Changelog
 
 
 class ManifestTests(unittest.TestCase):
@@ -16,6 +16,7 @@ class ManifestTests(unittest.TestCase):
         self.assertEqual(manifest.canonical.repo, "wevm/mppx")
         self.assertEqual(manifest.sdks["go"].automation, Automation.NOTIFY)
         self.assertEqual(manifest.pr_targets(), ("rust", "python"))
+        self.assertEqual(manifest.sdks["rust"].changelog, Changelog.FRAGMENT)
         self.assertEqual(manifest.sdks["ruby"].automation, Automation.NOTIFY)
 
     def test_rejects_pr_target_without_verification(self) -> None:

--- a/sdks.yaml
+++ b/sdks.yaml
@@ -20,7 +20,7 @@ sdks:
     repo: tempoxyz/mpp-rs
     automation: pr
     owners: [brendanjryan]
-    changelog: keep-a-changelog
+    changelog: fragment
     verify:
       - cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils,integration-stripe,integration-ws
 

--- a/sdks.yaml
+++ b/sdks.yaml
@@ -22,7 +22,7 @@ sdks:
     owners: [brendanjryan]
     changelog: keep-a-changelog
     verify:
-      - cargo test --all-features
+      - cargo test --features tempo,stripe,ws,server,client,axum,middleware,tower,utils,integration-stripe,integration-ws
 
   python:
     repo: tempoxyz/pympp


### PR DESCRIPTION
## Motivation

Rust remediation verification enables the devnet-only integration suite without starting Tempo, and its changelog convention is modeled as direct `CHANGELOG.md` editing despite requiring release fragments.

## Summary

- align Rust verification with the repository's normal CI feature set
- retain unit, Stripe integration, and WebSocket integration coverage while excluding Tempo-devnet tests
- add a first-class `fragment` changelog convention and apply it to mpp-rs
- document and validate the new manifest value

## Key design considerations

- reuse the downstream repository's established CI command
- keep verification isolated and free of external service credentials
- represent release fragments explicitly instead of treating them as no changelog