### PR TITLE
fix(agricola): parallelize remediation runs

### DIFF
--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -12,7 +12,15 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: agricola-control-plane
+  # Fixes are isolated by tracking issue. Ignored comments use unique groups so
+  # bot replies cannot replace pending commands.
+  group: >-
+    agricola-${{ github.event_name == 'issue_comment'
+    && contains(github.event.comment.body, '/ag')
+    && format('fix-{0}', github.event.issue.number)
+    || github.event_name == 'issue_comment'
+    && format('ignored-{0}', github.event.comment.id)
+    || 'control-plane' }}
   cancel-in-progress: false
 
 jobs:

--- a/agricola/tests/test_workflow.py
+++ b/agricola/tests/test_workflow.py
@@ -1,0 +1,28 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parents[2]
+
+
+class AgricolaWorkflowTests(unittest.TestCase):
+    def test_concurrency_scopes_commands_to_tracking_issue(self) -> None:
+        workflow = yaml.load(
+            (ROOT / ".github/workflows/agricola.yml").read_text(),
+            Loader=yaml.BaseLoader,
+        )
+
+        group = workflow["concurrency"]["group"]
+        command_filter = "contains(github.event.comment.body, '/ag')"
+        self.assertIn(command_filter, group)
+        self.assertIn(command_filter, workflow["jobs"]["run"]["if"])
+        self.assertIn("format('fix-{0}', github.event.issue.number)", group)
+        self.assertIn("format('ignored-{0}', github.event.comment.id)", group)
+        self.assertIn("|| 'control-plane'", group)
+        self.assertEqual(workflow["concurrency"]["cancel-in-progress"], "false")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Allow independent Agricola remediation commands to execute concurrently without bot replies canceling pending runs.

## Summary

- scope fix concurrency by tracking issue
- isolate ignored issue comments with unique concurrency groups
- preserve singleton control-plane scheduling
- add workflow regression coverage

## Key design considerations

- repeated commands for one tracking issue remain serialized
- active remediations are never canceled