### PR TITLE
feat(agricola): label created issues by affected SDK

### DIFF
--- a/agricola/README.md
+++ b/agricola/README.md
@@ -156,6 +156,7 @@ Ledger filenames identify the canonical repository and pull request. Entries con
 The separate `ledger/audit.json` registry maps stable fingerprints to finding IDs. It does not store mutable CI or pull-request lifecycle state.
 
 Tracking issue deduplication scans the control repository's issue API directly for the stable marker; it does not depend on search indexing.
+New tracking and audit issues receive the `agricola` label plus one label for every affected SDK. The audit index receives only `agricola`. Agricola creates missing labels before opening an issue.
 
 State-changing replies are deferred until the state pull request has been updated. A failed state update therefore cannot leave a misleading acknowledgement. Reruns reuse deterministic idempotency keys.
 

--- a/agricola/audit.py
+++ b/agricola/audit.py
@@ -10,6 +10,7 @@ from typing import Protocol
 
 from pydantic import ValidationError
 
+from .github import agricola_issue_labels
 from .ledger import AuditStore
 from .models import (
     AuditFindingContext,
@@ -478,7 +479,7 @@ def deliver_audit_report(
     for finding in pending.finding_issues:
         issue = findings_by_marker.get(finding.marker)
         if issue is None:
-            issue = client.create_issue(finding.title, finding.body)
+            issue = client.create_issue(finding.title, finding.body, finding.labels)
         else:
             body = preserve_propagation_state(
                 finding.body,
@@ -500,7 +501,7 @@ def deliver_audit_report(
 
     body = _link_finding_issues(pending.body, urls)
     if rollup is None:
-        return client.create_issue(pending.title, body)
+        return client.create_issue(pending.title, body, agricola_issue_labels())
     return client.update_issue(
         int(str(rollup["number"])),
         title=pending.title,
@@ -653,6 +654,7 @@ def _render_finding_issue(
         marker=marker,
         title=title,
         body="\n".join(lines).rstrip() + "\n",
+        labels=agricola_issue_labels(finding.affected),
     )
 
 

--- a/agricola/commands.py
+++ b/agricola/commands.py
@@ -223,6 +223,15 @@ def resolve_labels(
             notes=notes,
         )
 
+    affected = (
+        set(manifest.sdks)
+        if "agricola:all" in effective
+        else {
+            label.removeprefix("agricola:")
+            for label in effective
+            if label.removeprefix("agricola:") in manifest.sdks
+        }
+    )
     target_actors = {
         label.removeprefix("agricola:"): applied[label].actor
         for label in effective
@@ -244,6 +253,7 @@ def resolve_labels(
     return LabelResolution(
         labels=tuple(sorted(applied)),
         targets=tuple(sorted(target_actors)),
+        affected=tuple(sorted(affected)),
         target_actors=tuple(sorted(target_actors.items())),
         errors=errors,
         notes=tuple(

--- a/agricola/github.py
+++ b/agricola/github.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -20,6 +20,12 @@ from .models import (
 _SOURCE_MARKER = re.compile(
     r"<!--\s*agricola:source=([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)#([1-9][0-9]*)\s*-->"
 )
+_AGRICOLA_LABEL_COLOR = "6f42c1"
+_SDK_LABEL_COLOR = "bfdadc"
+
+
+def agricola_issue_labels(targets: Iterable[str] = ()) -> tuple[str, ...]:
+    return ("agricola", *sorted(set(targets)))
 
 
 class GitHubError(RuntimeError):
@@ -39,6 +45,7 @@ class GitHubClient:
         if token:
             self.environment["GH_TOKEN"] = token
         self.repo_tokens = repo_tokens or {}
+        self._known_issue_labels: set[str] | None = None
 
     def api(
         self,
@@ -236,12 +243,43 @@ class GitHubClient:
     def create_issue(
         self, title: str, body: str, labels: Sequence[str] = ()
     ) -> dict[str, object]:
+        self._ensure_issue_labels(labels)
         fields: dict[str, object] = {"title": title, "body": body}
         if labels:
             fields["labels"] = list(labels)
         return self.api(
             f"repos/{self.control_repo}/issues", method="POST", fields=fields
         )
+
+    def _ensure_issue_labels(self, labels: Sequence[str]) -> None:
+        if not labels:
+            return
+        if self._known_issue_labels is None:
+            pages = self.api(
+                f"repos/{self.control_repo}/labels?per_page=100", paginate=True
+            )
+            self._known_issue_labels = {
+                str(item["name"]).casefold() for page in pages for item in page
+            }
+        for label in labels:
+            normalized = label.casefold()
+            if normalized in self._known_issue_labels:
+                continue
+            fields = {
+                "name": label,
+                "color": (
+                    _AGRICOLA_LABEL_COLOR
+                    if normalized == "agricola"
+                    else _SDK_LABEL_COLOR
+                ),
+                "description": (
+                    "Issues managed by Agricola"
+                    if normalized == "agricola"
+                    else f"Issues affecting the {label} SDK"
+                ),
+            }
+            self.api(f"repos/{self.control_repo}/labels", method="POST", fields=fields)
+            self._known_issue_labels.add(normalized)
 
     def update_issue(
         self,

--- a/agricola/models.py
+++ b/agricola/models.py
@@ -256,6 +256,7 @@ class LabelEvent:
 class LabelResolution:
     labels: tuple[str, ...]
     targets: tuple[str, ...]
+    affected: tuple[str, ...] = ()
     target_actors: tuple[tuple[str, str], ...] = ()
     disabled: bool = False
     errors: tuple[str, ...] = ()
@@ -551,6 +552,7 @@ class PendingAuditFindingIssue(FrozenModel):
     marker: NonEmpty
     title: NonEmpty
     body: NonEmpty
+    labels: tuple[NonEmpty, ...] = ("agricola",)
 
 
 class PendingAuditReport(FrozenModel):

--- a/agricola/service.py
+++ b/agricola/service.py
@@ -18,7 +18,7 @@ from .commands import (
     require_maintainer,
     resolve_labels,
 )
-from .github import GitHubError
+from .github import GitHubError, agricola_issue_labels
 from .ledger import CursorStore, DecisionLedger
 from .models import (
     AuditFindingContext,
@@ -116,7 +116,11 @@ def poll(
         elif issue:
             counters["deduplicated"] += 1
         else:
-            issue = client.create_issue(tracking_issue_title(change), plan)
+            issue = client.create_issue(
+                tracking_issue_title(change),
+                plan,
+                agricola_issue_labels(resolution.affected),
+            )
             counters["created"] += 1
         if issue and not resolution.disabled and not resolution.errors:
             propagations.extend(

--- a/agricola/tests/test_audit.py
+++ b/agricola/tests/test_audit.py
@@ -49,6 +49,7 @@ class AuditGitHub:
             "title": title,
             "body": body,
             "state": "open",
+            "labels": tuple(labels),
             "html_url": f"https://github.com/tempoxyz/mpp-tools/issues/{number}",
         }
         self.issues.append(issue)
@@ -437,10 +438,13 @@ class AuditTests(unittest.TestCase):
         go = snapshot(
             "go", observations=(observation(check, AuditCheckStatus.FAILURE),)
         )
+        rust = snapshot(
+            "rust", observations=(observation(check, AuditCheckStatus.FAILURE),)
+        )
         with tempfile.TemporaryDirectory() as directory:
             report = build_audit_report(
                 manifest(),
-                (canonical, go, snapshot("rust"), snapshot("ruby")),
+                (canonical, go, rust, snapshot("ruby")),
                 AuditStore(directory),
                 at=datetime(2026, 8, 8, 18, 0, tzinfo=UTC),
             )
@@ -454,6 +458,8 @@ class AuditTests(unittest.TestCase):
             if "agricola:audit-finding" in str(issue["body"])
         )
         self.assertIn("AGR-2026-001", str(finding["title"]))
+        self.assertEqual(finding["labels"], ("agricola", "go", "rust"))
+        self.assertEqual(rollup["labels"], ("agricola",))
         self.assertIn(f"[AGR-2026-001]({finding['html_url']})", str(rollup["body"]))
 
     def test_healthy_delivery_closes_resolved_findings(self) -> None:

--- a/agricola/tests/test_commands.py
+++ b/agricola/tests/test_commands.py
@@ -151,12 +151,14 @@ class LabelTests(unittest.TestCase):
             [self.event(label) for label in labels], self.merged, self.manifest
         )
         self.assertEqual(result.targets, ("go", "rust"))
+        self.assertEqual(result.affected, ("go", "rust"))
 
     def test_all_expands_only_pr_targets(self) -> None:
         result = resolve_labels(
             [self.event("agricola:all")], self.merged, self.manifest
         )
         self.assertEqual(result.targets, ("go", "rust"))
+        self.assertEqual(result.affected, ("go", "ruby", "rust"))
         self.assertEqual(
             result.target_actors,
             (("go", "maintainer"), ("rust", "maintainer")),
@@ -168,6 +170,7 @@ class LabelTests(unittest.TestCase):
         )
 
         self.assertEqual(result.targets, ())
+        self.assertEqual(result.affected, ("ruby",))
         self.assertEqual(result.target_actors, ())
         self.assertEqual(
             result.notes,

--- a/agricola/tests/test_github.py
+++ b/agricola/tests/test_github.py
@@ -100,6 +100,38 @@ class GitHubApiTests(unittest.TestCase):
         self.assertIn("--input", command)
         self.assertEqual(json.loads(run.call_args.kwargs["input"]), {"title": "Title"})
 
+    def test_create_issue_provisions_and_applies_missing_labels(self) -> None:
+        client = StubClient(
+            [
+                [[{"name": "go"}]],
+                {"name": "agricola"},
+                {"number": 1},
+            ]
+        )
+
+        issue = client.create_issue("Title", "Body", ("agricola", "go"))
+
+        self.assertEqual(issue["number"], 1)
+        self.assertEqual(
+            client.calls[0][0], "repos/tempoxyz/mpp-tools/labels?per_page=100"
+        )
+        self.assertTrue(client.calls[0][1]["paginate"])
+        self.assertEqual(
+            client.calls[1],
+            (
+                "repos/tempoxyz/mpp-tools/labels",
+                {
+                    "method": "POST",
+                    "fields": {
+                        "name": "agricola",
+                        "color": "6f42c1",
+                        "description": "Issues managed by Agricola",
+                    },
+                },
+            ),
+        )
+        self.assertEqual(client.calls[2][1]["fields"]["labels"], ["agricola", "go"])
+
     @patch("agricola.github.subprocess.run")
     def test_api_failure_is_contextual(self, run) -> None:
         run.return_value = subprocess.CompletedProcess([], 1, "", "bad credentials")

--- a/agricola/tests/test_service.py
+++ b/agricola/tests/test_service.py
@@ -24,7 +24,7 @@ class FakeGitHub:
     def __init__(self) -> None:
         self.change = change()
         self.tracking = None
-        self.created: list[tuple[str, str]] = []
+        self.created: list[tuple[str, str, tuple[str, ...]]] = []
         self.updated: list[tuple[int, str | None, str | None]] = []
         self.comments: list[tuple[int, str]] = []
         self.pull_requests = 0
@@ -57,7 +57,7 @@ class FakeGitHub:
         return self.tracking
 
     def create_issue(self, title, body, labels=()):
-        self.created.append((title, body))
+        self.created.append((title, body, tuple(labels)))
         self.tracking = {
             "number": 99,
             "title": title,
@@ -111,6 +111,7 @@ class PollTests(unittest.TestCase):
             self.assertEqual(len(client.created), 1)
             self.assertEqual(client.pull_requests, 2)
             self.assertEqual(first.propagations[0].target, "go")
+            self.assertEqual(client.created[0][2], ("agricola", "go"))
             self.assertEqual(first.propagations[0].target_base_sha, "mpp-go1234567")
             self.assertEqual(second.propagations[0], first.propagations[0])
             self.assertEqual(store.load().merged_at, client.change.merged_at)
@@ -152,6 +153,28 @@ class PollTests(unittest.TestCase):
             )
             self.assertEqual(result.suppressed, 1)
             self.assertFalse(client.created)
+
+    def test_notify_only_issue_has_affected_sdk_label(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            client = FakeGitHub()
+            client.change = replace(client.change, labels=("agricola:ruby",))
+            client.events = (
+                LabelEvent(
+                    LabelAction.LABELED,
+                    "agricola:ruby",
+                    "maintainer",
+                    datetime(2026, 8, 7, 13, 59, tzinfo=UTC),
+                ),
+            )
+
+            poll(
+                client,
+                manifest(),
+                DecisionLedger(directory),
+                cursor_store(directory),
+            )
+
+            self.assertEqual(client.created[0][2], ("agricola", "ruby"))
 
     def test_none_conflict_creates_diagnostic_issue(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Motivation

Make Agricola-created issues immediately identifiable and filterable by affected SDK.

## Summary

- labels tracking and audit finding issues with `agricola` and each affected SDK
- labels the audit roll-up with `agricola`
- provisions missing control-repository labels before creating issues
- includes notify-only SDKs in affected-label resolution

## Key design considerations

- keeps issue labels distinct from canonical `agricola:*` propagation labels
- sorts and deduplicates SDK labels for deterministic issue payloads
- caches repository labels within each Agricola client run