### PR TITLE
feat(agricola): poll PR comments for fix commands

### DIFF
--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -82,9 +82,8 @@ jobs:
           permission-issues: read
           permission-pull-requests: read
 
-      - name: Create downstream repository read token
-        if: github.event_name == 'issue_comment'
-        id: downstream-read-token
+      - name: Create downstream command token
+        id: downstream-command-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.AGRICOLA_APP_ID }}
@@ -92,6 +91,7 @@ jobs:
           owner: ${{ steps.downstream-scope.outputs.owner }}
           repositories: ${{ steps.downstream-scope.outputs.repositories }}
           permission-contents: read
+          permission-issues: write
           permission-pull-requests: read
 
       - name: Process event
@@ -99,7 +99,7 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.control-token.outputs.token }}
           AGRICOLA_CANONICAL_TOKEN: ${{ steps.canonical-token.outputs.token }}
-          AGRICOLA_SDK_TOKEN: ${{ steps.downstream-read-token.outputs.token }}
+          AGRICOLA_SDK_TOKEN: ${{ steps.downstream-command-token.outputs.token }}
         run: |
           result="$RUNNER_TEMP/agricola-result.json"
           transaction=(
@@ -133,6 +133,11 @@ jobs:
           else
             echo "accepted-command=false" >> "$GITHUB_OUTPUT"
           fi
+          if jq -e '.acknowledgements | length > 0' "$result" >/dev/null; then
+            echo "has-pr-actions=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-pr-actions=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Acknowledge accepted command
         if: github.event_name == 'issue_comment' && steps.process.outputs.accepted-command == 'true'
@@ -143,6 +148,14 @@ jobs:
           gh api --method POST \
             "repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content=eyes
+
+      - name: Acknowledge polled PR commands
+        if: steps.process.outputs.has-pr-actions == 'true'
+        env:
+          GH_TOKEN: ${{ steps.downstream-command-token.outputs.token }}
+        run: |
+          agricola deliver-pr-actions "$RUNNER_TEMP/agricola-result.json" \
+            --action-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
 
       - name: Fetch GitHub token via STS
         id: sts

--- a/agricola/README.md
+++ b/agricola/README.md
@@ -6,6 +6,7 @@ It:
 
 - validates the reviewed [`sdks.yaml`](../sdks.yaml) manifest;
 - polls merged canonical pull requests with a durable Git-backed cursor;
+- polls recorded downstream PRs for maintainer `/ag fix` comments without an eyes acknowledgement;
 - reconstructs authorized `agricola:*` labels as they existed at merge time;
 - creates one tracking issue per actionable canonical change;
 - accepts maintainer-only `plan`, `fix`, `status`, and `skip` commands;
@@ -109,7 +110,9 @@ The tracking issue also contains a durable downstream propagation table. It list
 
 On an audit-finding issue, `fix` selects every affected PR-enabled SDK. Optional targets limit it to named affected SDKs, and `status` reports linked remediation pull requests. Each actionable issue includes a copy-ready `/ag fix` block. After a pull request is recorded, `/ag fix "instruction"` checks out its exact head, collects unresolved trusted review feedback and failed CI, makes an incremental verified revision, and posts a summary to the same pull request. The finding's exact canonical and target commits are the immutable initial-generation inputs. `plan` and `skip` remain specific to canonical-change issues.
 
-Commands in canonical or downstream repositories are not supported. A failed unpublished propagation can be retried by repeating its issue command or rerunning its workflow; a published stable branch is updated idempotently.
+Recorded downstream pull requests also accept `/ag fix instruction` as a top-level PR comment. The target is implicit, so the unquoted remainder is free-form. Scheduled polling ignores comments that already carry an eyes reaction, combines other authorized commands for the same PR into one exact-head revision, acknowledges them before generation, and replies on the PR with the Actions run link.
+
+Commands in the canonical repository are not supported, and downstream PRs accept only `fix`; other commands remain tracking-issue operations. A failed unpublished propagation can be retried by repeating its issue command or rerunning its workflow; a published stable branch is updated idempotently.
 
 ## Downstream execution
 
@@ -169,6 +172,7 @@ State-changing replies are deferred until the guarded state push succeeds and th
 | `agricola token-scope` | Prints the manifest-derived GitHub App scope for PR-enabled SDKs. | `agricola token-scope` |
 | `agricola poll` | Processes newly merged canonical pull requests. | `agricola poll --control-repo tempoxyz/mpp-tools` |
 | `agricola handle-comment [event]` | Parses an `issue_comment` payload; defaults to `GITHUB_EVENT_PATH`. | `agricola handle-comment event.json` |
+| `agricola deliver-pr-actions <result>` | Adds eyes reactions and run-link replies for accepted polled PR commands. | `agricola deliver-pr-actions result.json --action-url "$RUN_URL"` |
 | `agricola deliver-reply <file>` | Posts a deferred reply, optionally linking its Actions run. | `agricola deliver-reply reply.json --action-url "$RUN_URL"` |
 | `agricola deliver-issue-update <file>` | Applies a deferred tracking-issue body update. | `agricola deliver-issue-update update.json` |
 | `agricola record-propagations <results>` | Records published PRs or explicit skips and renders deferred updates. | `agricola record-propagations results --reply-directory replies --issue-update-directory updates` |

--- a/agricola/cli.py
+++ b/agricola/cli.py
@@ -36,6 +36,7 @@ from .manifest import (
 from .models import (
     AuditSemanticResult,
     Automation,
+    PendingAcknowledgement,
     PendingAuditReport,
     PendingIssueUpdate,
     PendingReply,
@@ -44,7 +45,12 @@ from .models import (
 )
 from .publisher import PublicationError, SubprocessGit, publish
 from .revision import collect_revision_feedback
-from .service import handle_comment, poll, record_propagations
+from .service import (
+    handle_comment,
+    poll,
+    record_propagations,
+    revision_acknowledgements,
+)
 from .state_transaction import GitStateStore, StateTransactionError, transact
 
 
@@ -103,6 +109,21 @@ def parser() -> argparse.ArgumentParser:
         help="append a link to the GitHub Actions run that produced the reply",
     )
     delivery.add_argument(
+        "--control-repo",
+        default=os.environ.get("GITHUB_REPOSITORY", "tempoxyz/mpp-tools"),
+    )
+
+    pr_delivery = subcommands.add_parser(
+        "deliver-pr-actions",
+        help="acknowledge polled PR commands and post their queued replies",
+    )
+    pr_delivery.add_argument("result_file")
+    pr_delivery.add_argument(
+        "--action-url",
+        required=True,
+        help="link to the GitHub Actions run processing the commands",
+    )
+    pr_delivery.add_argument(
         "--control-repo",
         default=os.environ.get("GITHUB_REPOSITORY", "tempoxyz/mpp-tools"),
     )
@@ -232,8 +253,49 @@ def main(argv: list[str] | None = None) -> int:
         body = reply.body
         if args.action_url:
             body = f"{body}\n\n[View fix run]({args.action_url})"
-        GitHubClient(args.control_repo).comment_issue(reply.issue_number, body)
+        client = GitHubClient(args.control_repo)
+        if reply.repository is None:
+            client.comment_issue(reply.issue_number, body)
+        else:
+            client.comment_repository_issue(reply.repository, reply.issue_number, body)
         print(json.dumps({"delivered": True, "issue_number": reply.issue_number}))
+        return 0
+    if args.command == "deliver-pr-actions":
+        try:
+            result = json.loads(Path(args.result_file).read_text())
+            acknowledgements = TypeAdapter(
+                tuple[PendingAcknowledgement, ...]
+            ).validate_python(result.get("acknowledgements", ()))
+            replies = TypeAdapter(tuple[PendingReply, ...]).validate_python(
+                result.get("replies", ())
+            )
+            if any(reply.repository is None for reply in replies):
+                raise ValueError("polled PR replies require a repository")
+        except (json.JSONDecodeError, OSError, ValidationError, ValueError) as exc:
+            print(f"PR action delivery error: {exc}", file=sys.stderr)
+            return 2
+        client = GitHubClient(args.control_repo)
+        for acknowledgement in acknowledgements:
+            client.react_to_issue_comment(
+                acknowledgement.repository,
+                acknowledgement.comment_id,
+                acknowledgement.content,
+            )
+        for reply in replies:
+            assert reply.repository is not None
+            client.comment_repository_issue(
+                reply.repository,
+                reply.issue_number,
+                f"{reply.body}\n\n[View fix run]({args.action_url})",
+            )
+        print(
+            json.dumps(
+                {
+                    "acknowledged": len(acknowledgements),
+                    "replies": len(replies),
+                }
+            )
+        )
         return 0
     if args.command == "deliver-issue-update":
         try:
@@ -519,8 +581,15 @@ def main(argv: list[str] | None = None) -> int:
                     **{
                         name: value
                         for name, value in result.__dict__.items()
-                        if name != "propagations"
+                        if name not in {"acknowledgements", "replies", "propagations"}
                     },
+                    "acknowledgements": [
+                        acknowledgement.model_dump(mode="json")
+                        for acknowledgement in result.acknowledgements
+                    ],
+                    "replies": [
+                        reply.model_dump(mode="json") for reply in result.replies
+                    ],
                     "propagations": [
                         request.model_dump(mode="json")
                         for request in result.propagations
@@ -543,6 +612,9 @@ def main(argv: list[str] | None = None) -> int:
         if args.issue_update_file:
             Path(args.issue_update_file).unlink(missing_ok=True)
         result = handle_comment(client, manifest, ledger, event)
+        acknowledgements = revision_acknowledgements(
+            client, manifest, result.propagations
+        )
         if result.reply is not None:
             if args.reply_file:
                 Path(args.reply_file).write_text(
@@ -570,6 +642,10 @@ def main(argv: list[str] | None = None) -> int:
                     and bool(args.reply_file),
                     "issue_update_deferred": result.issue_update is not None
                     and bool(args.issue_update_file),
+                    "acknowledgements": [
+                        acknowledgement.model_dump(mode="json")
+                        for acknowledgement in acknowledgements
+                    ],
                     "propagations": [
                         request.model_dump(mode="json")
                         for request in result.propagations

--- a/agricola/commands.py
+++ b/agricola/commands.py
@@ -16,7 +16,14 @@ from .models import (
 )
 
 _COMMAND_PREFIX = re.compile(r"^\s*/ag(?:ricola)?(?:\s+|$)", re.IGNORECASE)
+_PULL_REQUEST_FIX = re.compile(
+    r"^\s*/ag(?:ricola)?\s+fix(?:\s+(?P<instruction>.*?))?\s*$",
+    re.IGNORECASE,
+)
 _FIX_ALIASES = {"fix", "propagate", "propogate"}
+_DEFAULT_PULL_REQUEST_INSTRUCTION = (
+    "Address the current pull request feedback and failing CI."
+)
 
 
 class CommandError(ValueError):
@@ -34,6 +41,22 @@ def has_command_line(body: str) -> bool:
 def require_maintainer(author: str, manifest: Manifest) -> None:
     if author.lower() not in {login.lower() for login in manifest.maintainers}:
         raise AuthorizationError(f"@{author} is not authorized to operate Agricola")
+
+
+def parse_pull_request_fix(body: str, target: str) -> Command | None:
+    """Parse the first PR-local fix command, where the target is implicit."""
+    for line_number, line in enumerate(body.splitlines(), start=1):
+        match = _PULL_REQUEST_FIX.match(line)
+        if match is None:
+            continue
+        instruction = (match.group("instruction") or "").strip()
+        return Command(
+            verb=CommandVerb.PROPAGATE,
+            targets=(target,),
+            instruction=instruction or _DEFAULT_PULL_REQUEST_INSTRUCTION,
+            line=line_number,
+        )
+    return None
 
 
 def parse_commands(body: str, manifest: Manifest) -> list[Command]:

--- a/agricola/github.py
+++ b/agricola/github.py
@@ -14,6 +14,7 @@ from .models import (
     LabelAction,
     LabelEvent,
     PropagationRevision,
+    PullRequestComment,
     PullRequestFile,
 )
 
@@ -299,10 +300,42 @@ class GitHubClient:
         )
 
     def comment_issue(self, number: int, body: str) -> dict[str, object]:
+        return self.comment_repository_issue(self.control_repo, number, body)
+
+    def comment_repository_issue(
+        self, repository: str, number: int, body: str
+    ) -> dict[str, object]:
         return self.api(
-            f"repos/{self.control_repo}/issues/{number}/comments",
+            f"repos/{repository}/issues/{number}/comments",
             method="POST",
             fields={"body": body},
+        )
+
+    def pull_request_comments(self, reference: str) -> tuple[PullRequestComment, ...]:
+        repository, number = reference.rsplit("#", 1)
+        pages = self.api(
+            f"repos/{repository}/issues/{int(number)}/comments?per_page=100",
+            paginate=True,
+        )
+        return tuple(
+            PullRequestComment(
+                id=int(item["id"]),
+                body=str(item.get("body") or ""),
+                author=str((item.get("user") or {}).get("login") or ""),
+                created_at=_time(item["created_at"]),
+                has_eyes=int((item.get("reactions") or {}).get("eyes") or 0) > 0,
+            )
+            for page in pages
+            for item in page
+        )
+
+    def react_to_issue_comment(
+        self, repository: str, comment_id: int, content: str = "eyes"
+    ) -> None:
+        self.api(
+            f"repos/{repository}/issues/comments/{comment_id}/reactions",
+            method="POST",
+            fields={"content": content},
         )
 
     def source_from_body(self, body: str) -> tuple[str, int]:

--- a/agricola/models.py
+++ b/agricola/models.py
@@ -253,6 +253,15 @@ class LabelEvent:
 
 
 @dataclass(frozen=True)
+class PullRequestComment:
+    id: int
+    body: str
+    author: str
+    created_at: datetime
+    has_eyes: bool = False
+
+
+@dataclass(frozen=True)
 class LabelResolution:
     labels: tuple[str, ...]
     targets: tuple[str, ...]
@@ -376,6 +385,13 @@ PropagationOutcome = Annotated[
 class PendingReply(FrozenModel):
     issue_number: PositiveInt
     body: NonEmpty
+    repository: RepoName | None = None
+
+
+class PendingAcknowledgement(FrozenModel):
+    repository: RepoName
+    comment_id: PositiveInt
+    content: Literal["eyes"] = "eyes"
 
 
 class PendingIssueUpdate(FrozenModel):

--- a/agricola/service.py
+++ b/agricola/service.py
@@ -15,6 +15,7 @@ from .commands import (
     CommandError,
     has_command_line,
     parse_commands,
+    parse_pull_request_fix,
     require_maintainer,
     resolve_labels,
 )
@@ -32,6 +33,7 @@ from .models import (
     DecisionKind,
     LabelEvent,
     Manifest,
+    PendingAcknowledgement,
     PendingIssueUpdate,
     PendingReply,
     PropagateDecision,
@@ -39,6 +41,7 @@ from .models import (
     PropagationRequest,
     PropagationRevision,
     PropagationSkip,
+    PullRequestComment,
     Source,
     SkipDecision,
 )
@@ -57,6 +60,7 @@ class GitHub(Protocol):
     def repository_head(self, repo: str) -> str: ...
     def label_events(self, repo: str, number: int) -> Sequence[LabelEvent]: ...
     def find_tracking_issue(self, marker: str) -> dict[str, object] | None: ...
+    def find_tracking_issues(self, marker: str) -> tuple[dict[str, object], ...]: ...
     def create_issue(
         self, title: str, body: str, labels: Sequence[str] = ()
     ) -> dict[str, object]: ...
@@ -68,6 +72,9 @@ class GitHub(Protocol):
     def pull_revision(
         self, reference: str, expected_branch: str
     ) -> PropagationRevision: ...
+    def pull_request_comments(
+        self, reference: str
+    ) -> tuple[PullRequestComment, ...]: ...
 
 
 @dataclass(frozen=True)
@@ -76,6 +83,9 @@ class PollResult:
     created: int = 0
     deduplicated: int = 0
     suppressed: int = 0
+    pr_commands: int = 0
+    acknowledgements: tuple[PendingAcknowledgement, ...] = ()
+    replies: tuple[PendingReply, ...] = ()
     propagations: tuple[PropagationRequest, ...] = ()
 
 
@@ -139,7 +149,119 @@ def poll(
             counters["deduplicated"] += 1
         cursor = cursor.advance(change)
         cursor_store.save(cursor)
-    return PollResult(**counters, propagations=tuple(propagations))
+    pr_commands, acknowledgements, replies, revisions = _poll_pr_commands(
+        client, manifest, ledger
+    )
+    propagations.extend(revisions)
+    return PollResult(
+        **counters,
+        pr_commands=pr_commands,
+        acknowledgements=acknowledgements,
+        replies=replies,
+        propagations=tuple(propagations),
+    )
+
+
+def _poll_pr_commands(
+    client: GitHub,
+    manifest: Manifest,
+    ledger: DecisionLedger,
+) -> tuple[
+    int,
+    tuple[PendingAcknowledgement, ...],
+    tuple[PendingReply, ...],
+    tuple[PropagationRequest, ...],
+]:
+    command_count = 0
+    acknowledgements: list[PendingAcknowledgement] = []
+    replies: list[PendingReply] = []
+    propagations: list[PropagationRequest] = []
+    seen_references: set[str] = set()
+    for issue in client.find_tracking_issues("<!-- agricola:"):
+        for target, reference in recorded_propagations(
+            str(issue.get("body") or "")
+        ).items():
+            if reference in seen_references:
+                continue
+            seen_references.add(reference)
+            try:
+                sdk = manifest.target(target)
+            except ValueError:
+                continue
+            repository, number_text = reference.rsplit("#", 1)
+            if sdk.automation is not Automation.PR or sdk.repo != repository:
+                continue
+            candidates: list[tuple[PullRequestComment, Command]] = []
+            for comment in client.pull_request_comments(reference):
+                if comment.has_eyes:
+                    continue
+                try:
+                    require_maintainer(comment.author, manifest)
+                except AuthorizationError:
+                    continue
+                command = parse_pull_request_fix(comment.body, target)
+                if command is not None:
+                    candidates.append((comment, command))
+            if not candidates:
+                continue
+            candidates.sort(key=lambda item: (item[0].created_at, item[0].id))
+            instructions = tuple(
+                dict.fromkeys(
+                    command.instruction
+                    for _, command in candidates
+                    if command.instruction is not None
+                )
+            )
+            combined = "\n".join(instructions)
+            latest = candidates[-1][0]
+            result = handle_comment(
+                client,
+                manifest,
+                ledger,
+                {
+                    "comment": {
+                        "id": "pr-comments-"
+                        + "-".join(str(comment.id) for comment, _ in candidates),
+                        "body": latest.body,
+                        "created_at": latest.created_at.isoformat(),
+                        "user": {"login": latest.author},
+                    },
+                    "issue": issue,
+                },
+                commands=(
+                    Command(
+                        verb=CommandVerb.PROPAGATE,
+                        targets=(target,),
+                        instruction=combined,
+                    ),
+                ),
+            )
+            if result.ignored or not result.commands:
+                continue
+            command_count += len(candidates)
+            acknowledgements.extend(
+                PendingAcknowledgement(
+                    repository=repository,
+                    comment_id=comment.id,
+                )
+                for comment, _ in candidates
+            )
+            if result.reply is not None:
+                replies.append(
+                    result.reply.model_copy(
+                        update={
+                            "repository": repository,
+                            "issue_number": int(number_text),
+                        }
+                    )
+                )
+            propagations.extend(result.propagations)
+    return (
+        command_count,
+        tuple(acknowledgements),
+        tuple(replies),
+        tuple(propagations),
+    )
 
 
 @dataclass(frozen=True)
@@ -152,31 +274,60 @@ class CommentResult:
     propagations: tuple[PropagationRequest, ...] = ()
 
 
+def revision_acknowledgements(
+    client: GitHub,
+    manifest: Manifest,
+    requests: Sequence[PropagationRequest],
+) -> tuple[PendingAcknowledgement, ...]:
+    acknowledgements: dict[tuple[str, int], PendingAcknowledgement] = {}
+    for request in requests:
+        if request.revision is None:
+            continue
+        for comment in client.pull_request_comments(request.revision.pr):
+            if comment.has_eyes:
+                continue
+            try:
+                require_maintainer(comment.author, manifest)
+            except AuthorizationError:
+                continue
+            if parse_pull_request_fix(comment.body, request.target) is None:
+                continue
+            acknowledgement = PendingAcknowledgement(
+                repository=request.target_repo,
+                comment_id=comment.id,
+            )
+            acknowledgements[(request.target_repo, comment.id)] = acknowledgement
+    return tuple(acknowledgements.values())
+
+
 def handle_comment(
     client: GitHub,
     manifest: Manifest,
     ledger: DecisionLedger,
     event: dict[str, object],
+    *,
+    commands: Sequence[Command] | None = None,
 ) -> CommentResult:
     comment = _object(event, "comment")
     issue = _object(event, "issue")
     author = str(_object(comment, "user").get("login", ""))
     body = str(comment.get("body") or "")
-    if not has_command_line(body):
+    if commands is None and not has_command_line(body):
         return CommentResult(ignored=True)
     try:
         require_maintainer(author, manifest)
     except AuthorizationError:
         return CommentResult(ignored=True)
-    try:
-        commands = parse_commands(body, manifest)
-    except CommandError as exc:
-        return CommentResult(
-            reply=PendingReply(
-                issue_number=int(str(issue["number"])),
-                body=f"Agricola command error: {exc}",
+    if commands is None:
+        try:
+            commands = parse_commands(body, manifest)
+        except CommandError as exc:
+            return CommentResult(
+                reply=PendingReply(
+                    issue_number=int(str(issue["number"])),
+                    body=f"Agricola command error: {exc}",
+                )
             )
-        )
     if not commands:
         return CommentResult(ignored=True)
 

--- a/agricola/tests/test_cli.py
+++ b/agricola/tests/test_cli.py
@@ -170,6 +170,60 @@ class CliTests(unittest.TestCase):
                 ],
             )
 
+    def test_delivers_polled_pr_acknowledgement_and_run_link(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result_path = Path(directory) / "poll.json"
+            result_path.write_text(
+                json.dumps(
+                    {
+                        "acknowledgements": [
+                            {
+                                "repository": "tempoxyz/mpp-go",
+                                "comment_id": 55,
+                                "content": "eyes",
+                            }
+                        ],
+                        "replies": [
+                            {
+                                "repository": "tempoxyz/mpp-go",
+                                "issue_number": 88,
+                                "body": "Queued revision of `go`.",
+                            }
+                        ],
+                    }
+                )
+            )
+            action_url = (
+                "https://github.com/tempoxyz/mpp-tools/actions/runs/31281480045"
+            )
+            client = FakeGitHub()
+
+            with (
+                patch("agricola.cli.GitHubClient", return_value=client),
+                redirect_stdout(StringIO()),
+            ):
+                delivered = main(
+                    [
+                        "deliver-pr-actions",
+                        str(result_path),
+                        "--action-url",
+                        action_url,
+                    ]
+                )
+
+            self.assertEqual(delivered, 0)
+            self.assertEqual(client.reactions, [("tempoxyz/mpp-go", 55, "eyes")])
+            self.assertEqual(
+                client.repository_comments,
+                [
+                    (
+                        "tempoxyz/mpp-go",
+                        88,
+                        f"Queued revision of `go`.\n\n[View fix run]({action_url})",
+                    )
+                ],
+            )
+
     def test_records_explicit_generation_skip(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/agricola/tests/test_commands.py
+++ b/agricola/tests/test_commands.py
@@ -8,6 +8,7 @@ from agricola.commands import (
     CommandError,
     has_command_line,
     parse_commands,
+    parse_pull_request_fix,
     require_maintainer,
     resolve_labels,
 )
@@ -75,6 +76,28 @@ class CommandTests(unittest.TestCase):
     def test_unquoted_fix_instruction_is_an_unknown_target(self) -> None:
         with self.assertRaisesRegex(CommandError, "unknown SDK target"):
             parse_commands("/agricola fix address-comments", self.manifest)
+
+    def test_pr_fix_uses_implicit_target_and_freeform_instruction(self) -> None:
+        command = parse_pull_request_fix("/ag fix can you add more test coverage", "go")
+
+        self.assertIsNotNone(command)
+        assert command is not None
+        self.assertEqual(command.targets, ("go",))
+        self.assertEqual(command.instruction, "can you add more test coverage")
+
+    def test_pr_fix_without_instruction_uses_feedback_default(self) -> None:
+        command = parse_pull_request_fix("/ag fix", "go")
+
+        self.assertIsNotNone(command)
+        assert command is not None
+        assert command.instruction is not None
+        self.assertIn("pull request feedback", command.instruction)
+
+    def test_pr_parser_ignores_non_fix_commands_and_embedded_mentions(self) -> None:
+        self.assertIsNone(parse_pull_request_fix("/ag status", "go"))
+        self.assertIsNone(
+            parse_pull_request_fix("please run /ag fix add coverage", "go")
+        )
 
     def test_rejects_empty_fix_instruction(self) -> None:
         with self.assertRaisesRegex(CommandError, "must not be empty"):

--- a/agricola/tests/test_github.py
+++ b/agricola/tests/test_github.py
@@ -256,6 +256,55 @@ class GitHubApiTests(unittest.TestCase):
         with self.assertRaisesRegex(GitHubError, "does not use"):
             client.pull_revision("tempoxyz/mpp-go#88", "agricola/mppx-412")
 
+    def test_pull_request_comments_expose_eyes_acknowledgement(self) -> None:
+        client = StubClient(
+            [
+                [
+                    [
+                        {
+                            "id": 55,
+                            "body": "/ag fix add coverage",
+                            "created_at": "2026-08-09T03:22:26+00:00",
+                            "user": {"login": "maintainer"},
+                            "reactions": {"eyes": 1},
+                        },
+                        {
+                            "id": 56,
+                            "body": "/ag fix add another test",
+                            "created_at": "2026-08-09T03:23:26+00:00",
+                            "user": {"login": "maintainer"},
+                            "reactions": {"eyes": 0},
+                        },
+                    ]
+                ]
+            ]
+        )
+
+        comments = client.pull_request_comments("tempoxyz/mpp-go#88")
+
+        self.assertTrue(comments[0].has_eyes)
+        self.assertFalse(comments[1].has_eyes)
+        endpoint, options = client.calls[0]
+        self.assertEqual(
+            endpoint, "repos/tempoxyz/mpp-go/issues/88/comments?per_page=100"
+        )
+        self.assertTrue(options["paginate"])
+
+    def test_reacts_to_issue_comment_in_selected_repository(self) -> None:
+        client = StubClient([{"id": 1, "content": "eyes"}])
+
+        client.react_to_issue_comment("tempoxyz/mpp-go", 55)
+
+        self.assertEqual(
+            client.calls,
+            [
+                (
+                    "repos/tempoxyz/mpp-go/issues/comments/55/reactions",
+                    {"method": "POST", "fields": {"content": "eyes"}},
+                )
+            ],
+        )
+
     def test_tracking_issue_deduplication_uses_direct_issue_listing(self) -> None:
         marker = "<!-- agricola:source=wevm/mppx#412 -->"
         client = StubClient([[[{"number": 9, "body": marker}]]])

--- a/agricola/tests/test_service.py
+++ b/agricola/tests/test_service.py
@@ -15,18 +15,30 @@ from agricola.models import (
     PropagationResult,
     PropagationRevision,
     PropagationSkip,
+    PullRequestComment,
 )
-from agricola.service import handle_comment, poll, record_propagations
+from agricola.service import (
+    handle_comment,
+    poll,
+    record_propagations,
+    revision_acknowledgements,
+)
 from agricola.tests.helpers import change, manifest
 
 
 class FakeGitHub:
     def __init__(self) -> None:
         self.change = change()
+        self.changes = ()
+        self.poll_current_change = True
         self.tracking = None
+        self.tracking_issues: tuple[dict[str, object], ...] | None = None
+        self.pr_comments: dict[str, tuple[PullRequestComment, ...]] = {}
         self.created: list[tuple[str, str, tuple[str, ...]]] = []
         self.updated: list[tuple[int, str | None, str | None]] = []
         self.comments: list[tuple[int, str]] = []
+        self.repository_comments: list[tuple[str, int, str]] = []
+        self.reactions: list[tuple[str, int, str]] = []
         self.pull_requests = 0
         self.source_repo = "wevm/mppx"
         self.repository_heads: list[str] = []
@@ -40,7 +52,7 @@ class FakeGitHub:
         )
 
     def merged_changes(self, repo, cursor):
-        return [self.change]
+        return [self.change] if self.poll_current_change else list(self.changes)
 
     def pull_request(self, repo, number):
         self.pull_requests += 1
@@ -55,6 +67,11 @@ class FakeGitHub:
 
     def find_tracking_issue(self, marker):
         return self.tracking
+
+    def find_tracking_issues(self, marker):
+        if self.tracking_issues is not None:
+            return self.tracking_issues
+        return () if self.tracking is None else (self.tracking,)
 
     def create_issue(self, title, body, labels=()):
         self.created.append((title, body, tuple(labels)))
@@ -74,6 +91,13 @@ class FakeGitHub:
         self.comments.append((number, body))
         return {"id": len(self.comments)}
 
+    def comment_repository_issue(self, repository, number, body):
+        self.repository_comments.append((repository, number, body))
+        return {"id": len(self.repository_comments)}
+
+    def react_to_issue_comment(self, repository, comment_id, content="eyes"):
+        self.reactions.append((repository, comment_id, content))
+
     def source_from_body(self, body):
         if "agricola:source=" not in body:
             raise GitHubError("missing source")
@@ -88,6 +112,9 @@ class FakeGitHub:
             url=f"https://github.com/{reference.replace('#', '/pull/')}",
             head_sha="def1234567",
         )
+
+    def pull_request_comments(self, reference):
+        return self.pr_comments.get(reference, ())
 
 
 def cursor_store(directory: str) -> CursorStore:
@@ -270,6 +297,101 @@ class PollTests(unittest.TestCase):
             self.assertEqual(
                 tuple(item.target for item in result.propagations), ("go",)
             )
+
+    def test_queues_unacknowledged_pr_fix_with_freeform_instruction(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            client = FakeGitHub()
+            client.poll_current_change = False
+            client.tracking_issues = (
+                {
+                    "number": 97,
+                    "title": "[Agricola] AGR-2026-022: Challenge selection differs",
+                    "html_url": "https://github.com/tempoxyz/mpp-tools/issues/97",
+                    "body": """<!-- agricola:audit-finding=AGR-2026-022 -->
+# AGR-2026-022 — Challenge selection differs
+
+## Audited heads
+
+| Target | Repository | Commit | Conformance | Semantic review |
+| --- | --- | --- | --- | --- |
+| `typescript` | `wevm/mppx` | [`b7ab48e38e3d`](https://github.com/wevm/mppx/commit/b7ab48e38e3d) | Complete | Reference |
+| `go` | `tempoxyz/mpp-go` | [`9cad840de723`](https://github.com/tempoxyz/mpp-go/commit/9cad840de723) | Complete | Complete |
+
+## Finding
+
+- Fingerprint: `semantic:challenge-negotiation/select-supported-method-intent`
+- Affected SDKs: `go`
+
+<!-- agricola:propagation-table:start -->
+| Target | Automation | Status | Pull request |
+| --- | --- | --- | --- |
+| `go` | pr | Recorded | [tempoxyz/mpp-go#91](https://github.com/tempoxyz/mpp-go/pull/91) |
+<!-- agricola:propagation-table:end -->
+""",
+                },
+            )
+            client.pr_comments["tempoxyz/mpp-go#91"] = (
+                PullRequestComment(
+                    id=55,
+                    body="/ag fix can you add more test coverage",
+                    author="maintainer",
+                    created_at=datetime(2026, 8, 8, 3, 22, tzinfo=UTC),
+                ),
+            )
+
+            result = poll(
+                client,
+                manifest(),
+                DecisionLedger(directory),
+                cursor_store(directory),
+            )
+
+            self.assertEqual(result.pr_commands, 1)
+            self.assertEqual(len(result.propagations), 1)
+            request = result.propagations[0]
+            self.assertEqual(request.target, "go")
+            self.assertEqual(request.instruction, "can you add more test coverage")
+            assert request.revision is not None
+            self.assertEqual(request.revision.pr, "tempoxyz/mpp-go#91")
+            self.assertEqual(result.acknowledgements[0].comment_id, 55)
+            self.assertEqual(result.replies[0].repository, "tempoxyz/mpp-go")
+            self.assertEqual(result.replies[0].issue_number, 91)
+
+    def test_ignores_pr_fix_already_reacted_to_with_eyes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            client = FakeGitHub()
+            client.poll_current_change = False
+            client.tracking_issues = (
+                {
+                    "number": 99,
+                    "body": """<!-- agricola:source=wevm/mppx#412 -->
+<!-- agricola:propagation-table:start -->
+| Target | Automation | Status | Pull request |
+| --- | --- | --- | --- |
+| `go` | pr | Recorded | [tempoxyz/mpp-go#88](https://github.com/tempoxyz/mpp-go/pull/88) |
+<!-- agricola:propagation-table:end -->
+""",
+                },
+            )
+            client.pr_comments["tempoxyz/mpp-go#88"] = (
+                PullRequestComment(
+                    id=56,
+                    body="/ag fix add coverage",
+                    author="maintainer",
+                    created_at=datetime(2026, 8, 8, 3, 22, tzinfo=UTC),
+                    has_eyes=True,
+                ),
+            )
+
+            result = poll(
+                client,
+                manifest(),
+                DecisionLedger(directory),
+                cursor_store(directory),
+            )
+
+            self.assertEqual(result.pr_commands, 0)
+            self.assertFalse(result.acknowledgements)
 
 
 class CommentTests(unittest.TestCase):
@@ -702,6 +824,51 @@ class CommentTests(unittest.TestCase):
             assert result.reply is not None
             self.assertIn("merged canonical pull request", result.reply.body)
             self.assertEqual(client.pull_requests, 0)
+
+    def test_issue_revision_acknowledges_unhandled_pr_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            client = FakeGitHub()
+            event = self.audit_event(
+                '/ag fix go "address the review and failing tests"'
+            )
+            event["issue"]["body"] += """
+<!-- agricola:propagation-table:start -->
+| Target | Automation | Status | Pull request |
+| --- | --- | --- | --- |
+| `go` | pr | Recorded | [tempoxyz/mpp-go#91](https://github.com/tempoxyz/mpp-go/pull/91) |
+<!-- agricola:propagation-table:end -->
+"""
+            client.pr_comments["tempoxyz/mpp-go#91"] = (
+                PullRequestComment(
+                    id=55,
+                    body="/ag fix add more coverage",
+                    author="maintainer",
+                    created_at=datetime(2026, 8, 8, 3, 22, tzinfo=UTC),
+                ),
+                PullRequestComment(
+                    id=56,
+                    body="/ag fix already handled",
+                    author="maintainer",
+                    created_at=datetime(2026, 8, 8, 3, 23, tzinfo=UTC),
+                    has_eyes=True,
+                ),
+            )
+
+            result = handle_comment(
+                client,
+                manifest(),
+                DecisionLedger(directory),
+                event,
+            )
+            acknowledgements = revision_acknowledgements(
+                client, manifest(), result.propagations
+            )
+
+            self.assertEqual(len(result.propagations), 1)
+            self.assertEqual(
+                [acknowledgement.comment_id for acknowledgement in acknowledgements],
+                [55],
+            )
 
 
 if __name__ == "__main__":

--- a/agricola/tests/test_workflow.py
+++ b/agricola/tests/test_workflow.py
@@ -75,6 +75,17 @@ class AgricolaWorkflowTests(unittest.TestCase):
         )
         self.assertIn("Compare SDK implementation to canonical mppx", self.audit_text)
 
+    def test_polling_token_can_acknowledge_downstream_pr_commands(self) -> None:
+        run = self.control["jobs"]["run"]
+        token = next(
+            step
+            for step in run["steps"]
+            if step.get("id") == "downstream-command-token"
+        )
+        self.assertNotIn("if", token)
+        self.assertEqual(token["with"]["permission-issues"], "write")
+        self.assertIn("agricola deliver-pr-actions", self.control_text)
+
     def test_publication_logic_runs_through_tested_cli(self) -> None:
         self.assertIn("agricola publish-propagation", self.control_text)
         self.assertNotIn("gh pr create", self.control_text)

--- a/docs/agricola-actions.md
+++ b/docs/agricola-actions.md
@@ -8,7 +8,7 @@ Both semantic analysis and downstream generation explicitly use `gpt-5.6-sol`. D
 
 | Trigger | Behavior |
 | --- | --- |
-| Ten-minute schedule | Poll merged `wevm/mppx` pull requests; create tracking issues only for authorized merge-time `agricola:all` or `agricola:<target>` labels. GitHub may delay scheduled jobs. |
+| Ten-minute schedule | Poll merged `wevm/mppx` pull requests and unacknowledged `/ag fix` comments on recorded downstream PRs; create tracking issues only for authorized merge-time `agricola:all` or `agricola:<target>` labels. GitHub may delay scheduled jobs. |
 | `workflow_dispatch` | Run the poller manually. |
 | New `issue_comment` containing `/ag` | Handle a tracking-issue command. `/ag` must be the first token on a line; `/agricola` remains an alias for existing comments. |
 
@@ -83,7 +83,7 @@ Downstream code never runs in a job containing downstream write credentials. Gen
 7. On a tracking issue, run `/ag fix <target>` and confirm the eyes reaction, generation, verification, a downstream draft pull request, and a recorded ledger decision.
 8. Run the SDK audit manually and confirm the `[Agricola] SDK drift audit` index links one issue per finding and records every exact audited commit.
 9. On an affected PR-enabled finding, copy and post `/ag fix` and confirm the finding links the resulting draft remediation pull request.
-10. Add a review comment or failing check to that draft, post `/ag fix "address the review and CI"` on its tracking issue, and confirm the same PR receives an incremental commit and summary comment.
+10. Post `/ag fix address the review and CI` on the draft PR, wait for the scheduled poll, and confirm the comment receives an eyes reaction, a run-link reply, and an incremental commit with a summary comment. A quoted `/ag fix "instruction"` on the tracking issue remains supported.
 
 The initial cursor starts fifteen minutes in the past. Because each poll replays a one-hour overlap, the first API read covers approximately the previous 75 minutes. To backfill a different window, update the state pull request with a reviewed `ledger/cursor.json` containing a timezone-aware ISO 8601 `merged_at`; polling begins one hour before it.
 
@@ -95,7 +95,7 @@ The maintainer allowlist lives in [`sdks.yaml`](../sdks.yaml). Agricola reconstr
 
 Commands use deferred issue updates and replies so acknowledgements follow their corresponding state change. Canonical-change tables reflect the durable decision ledger. Audit-finding tables retain linked remediation pull requests across later audit runs. Skip decisions use the comment ID and line number. Canonical propagation branches use `agricola/<canonical-repo>-<pr-number>`; audit remediation branches use `agricola/<finding-id>`. Replaying a poll, comment, job, or state overlap therefore reuses existing work instead of opening duplicate pull requests.
 
-On an audit-finding issue, `/ag fix` generates, verifies, and opens draft fixes for all affected PR-enabled SDKs. Optional target names narrow the request. Once a PR is recorded, `/ag fix "instruction"` ingests unresolved owner/member/collaborator review feedback plus failed checks and Actions logs, revises the exact current head, verifies it, fast-forwards the same branch, and posts a summary. Accepted fixes reply with a direct link to the exact Actions run. `/ag status` reports linked remediation pull requests. Every actionable finding includes a copy-ready quick command, and valid maintainer commands receive an eyes reaction when processing begins. `/agricola` remains a compatibility alias for the command prefix.
+On an audit-finding issue, `/ag fix` generates, verifies, and opens draft fixes for all affected PR-enabled SDKs. Optional target names narrow the request. Once a PR is recorded, `/ag fix "instruction"` on the tracking issue or `/ag fix instruction` on the PR ingests unresolved owner/member/collaborator review feedback plus failed checks and Actions logs, revises the exact current head, verifies it, fast-forwards the same branch, and posts a summary. PR-local targets are implicit, and all text after `fix` is the instruction. Scheduled polling ignores PR commands that already have an eyes reaction and acknowledges accepted commands before generation, so an overlapping issue-driven revision can mark the same feedback as handled. Accepted fixes reply with a direct link to the exact Actions run. `/ag status` reports linked remediation pull requests. Every actionable finding includes a copy-ready quick command, and valid maintainer commands receive an eyes reaction when processing begins. `/agricola` remains a compatibility alias for the command prefix.
 
 ## Manual poll
 


### PR DESCRIPTION
## Motivation

Allow maintainers to request incremental Agricola revisions directly from recorded downstream pull requests without hosting an additional webhook service.

## Summary

- poll recorded downstream PRs for unacknowledged `/ag fix` comments
- treat PR-local command text as a free-form instruction with an implicit SDK target
- add eyes acknowledgements and PR replies linking the exact control-plane run
- mark PR commands incorporated by tracking-issue revisions as handled
- document and test polling, filtering, delivery, and workflow permissions

## Key design considerations

- skip any command that already has an eyes reaction
- combine pending commands for one PR into a single exact-head revision
- authorize command authors against the existing maintainer allowlist
- keep downstream issue-write credentials in the control-plane job and outside generated-code execution