### PR TITLE
fix(agricola): require labels for canonical tickets

### DIFF
--- a/agricola/README.md
+++ b/agricola/README.md
@@ -78,7 +78,7 @@ Apply labels to the canonical pull request before merging:
 | `agricola:all` | Queue every manifest target with `automation: pr`. |
 | `agricola:<target>` | Queue the named target; target labels are additive. |
 | `agricola:none` | Disable propagation. A clean `none` result is recorded without a tracking issue. |
-| No Agricola label | Create a tracking issue and await a command. |
+| No Agricola label | Record the merge without creating a tracking issue or propagating it. |
 
 Only the last label event at or before merge counts, and its actor must be in `maintainers`. Later label edits cannot change the snapshot. Unknown authorized labels create a diagnostic plan. `agricola:none` wins over other labels, but conflicts and errors remain visible in a diagnostic tracking issue.
 
@@ -92,7 +92,7 @@ Each tracking issue contains the stable marker `<!-- agricola:source=OWNER/REPO#
 2. canonical behavior worth matching;
 3. incidental repository or TypeScript tooling files.
 
-Agricola does not infer SDK applicability from keywords or feature tags. Authorized merge-time labels and maintainer commands are the only propagation decisions. Plans show the selected targets and the manifest's general target inventory; `automation: notify` targets remain notification-only.
+Agricola does not infer SDK applicability from keywords or feature tags. Authorized merge-time labels are required to create a tracking issue from a canonical merge. Maintainer commands can then refine propagation decisions on that issue. Plans show the selected targets and the manifest's general target inventory; `automation: notify` targets remain notification-only.
 
 The tracking issue also contains a durable downstream propagation table. It lists every target as awaiting a decision, queued, skipped, notification-only, or recorded, and links each recorded downstream pull request. Table updates are delivered only after the corresponding ledger state has been persisted.
 

--- a/agricola/commands.py
+++ b/agricola/commands.py
@@ -255,6 +255,7 @@ def resolve_labels(
         targets=tuple(sorted(target_actors)),
         affected=tuple(sorted(affected)),
         target_actors=tuple(sorted(target_actors.items())),
+        disabled=not effective,
         errors=errors,
         notes=tuple(
             f"{target} is notify-only; no downstream PR was queued"

--- a/agricola/tests/test_audit.py
+++ b/agricola/tests/test_audit.py
@@ -426,7 +426,7 @@ class AuditTests(unittest.TestCase):
         self.assertFalse(pending.healthy)
         self.assertIn("go: semantic review is missing", pending.body)
 
-    def test_matrix_requires_every_manifest_adapter(self) -> None:
+    def test_matrix_includes_every_manifest_sdk(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             for target in manifest().sdks:

--- a/agricola/tests/test_commands.py
+++ b/agricola/tests/test_commands.py
@@ -145,6 +145,14 @@ class LabelTests(unittest.TestCase):
     ) -> LabelEvent:
         return LabelEvent(action, label, actor, self.merged + timedelta(minutes=offset))
 
+    def test_no_label_disables_propagation(self) -> None:
+        result = resolve_labels([], self.merged, self.manifest)
+
+        self.assertTrue(result.disabled)
+        self.assertEqual(result.labels, ())
+        self.assertEqual(result.targets, ())
+        self.assertEqual(result.affected, ())
+
     def test_additive_targets(self) -> None:
         labels = ["agricola:go", "agricola:rust"]
         result = resolve_labels(

--- a/agricola/tests/test_service.py
+++ b/agricola/tests/test_service.py
@@ -154,6 +154,23 @@ class PollTests(unittest.TestCase):
             self.assertEqual(result.suppressed, 1)
             self.assertFalse(client.created)
 
+    def test_unlabeled_change_suppresses_tracking_issue(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            client = FakeGitHub()
+            client.change = replace(client.change, labels=())
+            client.events = ()
+
+            result = poll(
+                client,
+                manifest(),
+                DecisionLedger(directory),
+                cursor_store(directory),
+            )
+
+            self.assertEqual(result.suppressed, 1)
+            self.assertFalse(client.created)
+            self.assertFalse(result.propagations)
+
     def test_notify_only_issue_has_affected_sdk_label(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             client = FakeGitHub()

--- a/agricola/tests/test_workflow.py
+++ b/agricola/tests/test_workflow.py
@@ -49,6 +49,24 @@ class AgricolaWorkflowTests(unittest.TestCase):
         self.assertIn("owner: ${{ matrix.owner }}", self.control_text)
         self.assertIn("repositories: ${{ matrix.repository }}", self.control_text)
 
+    def test_recurring_audit_compares_each_sdk_to_pinned_canonical(self) -> None:
+        target = self.audit["jobs"]["target"]
+        self.assertEqual(self.audit["on"]["schedule"][0]["cron"], "0 9 * * 1")
+        self.assertIn("agricola audit-matrix", self.audit_text)
+        self.assertEqual(
+            target["strategy"]["matrix"],
+            "${{ fromJSON(needs.prepare.outputs.matrix) }}",
+        )
+        self.assertIn("repository: ${{ matrix.repo }}", self.audit_text)
+        self.assertIn(
+            "repository: ${{ needs.prepare.outputs.canonical-repo }}",
+            self.audit_text,
+        )
+        self.assertIn(
+            "ref: ${{ needs.prepare.outputs.canonical-sha }}", self.audit_text
+        )
+        self.assertIn("Compare SDK implementation to canonical mppx", self.audit_text)
+
     def test_publication_logic_runs_through_tested_cli(self) -> None:
         self.assertIn("agricola publish-propagation", self.control_text)
         self.assertNotIn("gh pr create", self.control_text)

--- a/docs/agricola-actions.md
+++ b/docs/agricola-actions.md
@@ -8,11 +8,11 @@ Both semantic analysis and downstream generation explicitly use `gpt-5.6-sol`. D
 
 | Trigger | Behavior |
 | --- | --- |
-| Ten-minute schedule | Poll merged `wevm/mppx` pull requests. GitHub may delay scheduled jobs. |
+| Ten-minute schedule | Poll merged `wevm/mppx` pull requests; create tracking issues only for authorized merge-time `agricola:all` or `agricola:<target>` labels. GitHub may delay scheduled jobs. |
 | `workflow_dispatch` | Run the poller manually. |
 | New `issue_comment` containing `/ag` | Handle a tracking-issue command. `/ag` must be the first token on a line; `/agricola` remains an alias for existing comments. |
 
-The audit workflow runs every Monday at 09:00 UTC and supports `workflow_dispatch`. For each manifest SDK, it checks out the exact current heads of that repository and `mppx`, runs an open-ended read-only Codex comparison, and requires schema-validated findings with linked code evidence. Shared vectors and conformance-adapter capabilities remain deterministic supporting signals. Agricola clusters matching `semantic:`, `vector:`, and `capability:` fingerprints, maintains one issue per finding, and updates a roll-up index. The audit itself is read-only outside `mpp-tools`; downstream publication requires a maintainer's explicit command on a finding issue.
+The audit workflow runs every Monday at 09:00 UTC and supports `workflow_dispatch`. Independently of canonical pull-request labels, every run re-baselines each manifest SDK against the same pinned current `mppx` head. Each matrix job checks out the exact current head of its SDK and the pinned `mppx` head, runs an open-ended read-only Codex comparison, and requires schema-validated findings with linked code evidence. Shared vectors and conformance-adapter capabilities remain deterministic supporting signals. Agricola clusters matching `semantic:`, `vector:`, and `capability:` fingerprints, maintains one issue per finding, and updates a roll-up index. The audit itself is read-only outside `mpp-tools`; downstream publication requires a maintainer's explicit command on a finding issue.
 
 Semantic findings are open-ended review results. If another SDK review does not report the same fingerprint, the roll-up says `not reported`; only deterministic capability and conformance checks can report an SDK as `clean`. The audit does not infer a likely origin from affected-target counts.
 
@@ -91,7 +91,7 @@ Ledger-only state pull requests skip repository CI and SDK conformance workflow 
 
 ## Labels, commands, and idempotency
 
-The maintainer allowlist lives in [`sdks.yaml`](../sdks.yaml). Agricola reconstructs label state from canonical issue events at or before merge. A label is effective only when its final pre-merge application came from a configured maintainer. Unknown labels and conflicts create diagnostic plans. A clean `agricola:none` result is recorded without an issue. Post-merge edits do not change recorded state.
+The maintainer allowlist lives in [`sdks.yaml`](../sdks.yaml). Agricola reconstructs label state from canonical issue events at or before merge. A label is effective only when its final pre-merge application came from a configured maintainer. An unlabeled change is recorded without an issue or propagation. Unknown labels and conflicts create diagnostic plans. A clean `agricola:none` result is also recorded without an issue. Post-merge edits do not change recorded state.
 
 Commands use deferred issue updates and replies so acknowledgements follow their corresponding state change. Canonical-change tables reflect the durable decision ledger. Audit-finding tables retain linked remediation pull requests across later audit runs. Skip decisions use the comment ID and line number. Canonical propagation branches use `agricola/<canonical-repo>-<pr-number>`; audit remediation branches use `agricola/<finding-id>`. Replaying a poll, comment, job, or state overlap therefore reuses existing work instead of opening duplicate pull requests.
 


### PR DESCRIPTION
## Motivation

Canonical MPPx pull-request tracking should remain opt-in during the initial rollout, while recurring SDK audits continue to re-baseline every SDK against MPPx.

## Summary

- suppress tracking issues and propagation for canonical merges without an authorized opt-in label
- preserve diagnostic issues for invalid or conflicting labels
- document and test the label-independent recurring SDK audit boundary

## Key design considerations

- canonical polling accepts agricola:all and agricola:<target> as opt-in labels
- the weekly audit still uses a manifest-derived SDK matrix and one pinned MPPx head