### PR TITLE
ci(agricola): open the state PR via github-sts

### DIFF
--- a/.github/sts/agricola-state.sts.yaml
+++ b/.github/sts/agricola-state.sts.yaml
@@ -1,0 +1,12 @@
+# Allow the Agricola control plane workflow (schedule / workflow_dispatch /
+# issue_comment, all running against main) to mint a short-lived token that
+# opens the agricola/state checkpoint pull request. Replaces the built-in
+# GITHUB_TOKEN so the org can turn off "Allow GitHub Actions to create and
+# approve pull requests". The state branch itself is still pushed with the
+# built-in token's contents: write.
+subject: repo:tempoxyz@211589300/mpp-tools@1255838786:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: tempoxyz/mpp-tools/\.github/workflows/agricola\.yml@refs/heads/main
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -7,9 +7,16 @@ on:
   issue_comment:
     types: [created]
 
+# contents: write lets `agricola state-transaction` push the agricola/state
+# branch with the checkout credentials (branch pushes stay on the built-in
+# token). The state pull request itself is opened with a short-lived GitHub
+# App token minted via github-sts (authorized by
+# .github/sts/agricola-state.sts.yaml) because the built-in GITHUB_TOKEN is
+# not allowed to create pull requests. id-token lets those jobs request the
+# OIDC token the STS exchange verifies.
 permissions:
   contents: write
-  pull-requests: write
+  id-token: write
 
 concurrency:
   # Fixes are isolated by tracking issue. Ignored comments use unique groups so
@@ -137,10 +144,16 @@ jobs:
             "repos/$GITHUB_REPOSITORY/issues/comments/${{ github.event.comment.id }}/reactions" \
             -f content=eyes
 
+      - name: Fetch GitHub token via STS
+        id: sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        with:
+          policy: agricola-state
+
       - name: Ensure state pull request
         uses: ./.github/actions/persist-agricola-state
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.sts.outputs.token }}
           base: ${{ env.DEFAULT_BRANCH }}
           branch: ${{ env.STATE_BRANCH }}
 
@@ -523,10 +536,16 @@ jobs:
               --reply-directory "$RUNNER_TEMP/replies" \
               --issue-update-directory "$RUNNER_TEMP/issue-updates"
 
+      - name: Fetch GitHub token via STS
+        id: sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        with:
+          policy: agricola-state
+
       - name: Ensure state pull request
         uses: ./.github/actions/persist-agricola-state
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.sts.outputs.token }}
           base: ${{ env.DEFAULT_BRANCH }}
           branch: ${{ env.STATE_BRANCH }}
 


### PR DESCRIPTION
## Motivation

We are disabling the org-level **"Allow GitHub Actions to create and approve pull requests"** setting, after which the built-in `GITHUB_TOKEN` can no longer open or approve pull requests. The `run` and `record` jobs open the `agricola/state` checkpoint PR through `persist-agricola-state` with `github.token`.

## Changes

- Mint a short-lived GitHub App token via STS (`tempoxyz/gh-actions/actions/github-sts`, SHA-pinned) in both jobs and pass it to `persist-agricola-state` (the composite action is unchanged — it already takes the token as an input).
- Replace `pull-requests: write` with `id-token: write` at the workflow level. `contents: write` stays: `agricola state-transaction` still pushes the state branch with the checkout credentials, and branch pushes are unaffected by the org setting.
- Add `.github/sts/agricola-state.sts.yaml`: subject pinned to this repo's `main` ref with a `job_workflow_ref` claim check on this workflow, granting `contents: write` + `pull_requests: write`.

## Notes

- Sibling PRs migrate `agricola-audit.yml` (same pattern, own policy) and `dependabot.yml`.
- Verify by dispatching **Agricola control plane** after merge.

