### PR TITLE
ci(agricola-audit): open the state PR via github-sts

### DIFF
--- a/.github/sts/agricola-audit-state.sts.yaml
+++ b/.github/sts/agricola-audit-state.sts.yaml
@@ -1,0 +1,12 @@
+# Allow the Agricola SDK audit workflow (schedule / workflow_dispatch on
+# main) to mint a short-lived token that opens the agricola/state checkpoint
+# pull request after the audit roll-up. Replaces the built-in GITHUB_TOKEN so
+# the org can turn off "Allow GitHub Actions to create and approve pull
+# requests". The state branch itself is still pushed with the built-in
+# token's contents: write.
+subject: repo:tempoxyz@211589300/mpp-tools@1255838786:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: tempoxyz/mpp-tools/\.github/workflows/agricola-audit\.yml@refs/heads/main
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/agricola-audit.yml
+++ b/.github/workflows/agricola-audit.yml
@@ -260,9 +260,16 @@ jobs:
     needs: [prepare, canonical, target]
     if: always() && needs.prepare.result == 'success'
     runs-on: ubuntu-latest
+    # contents: write lets `agricola state-transaction` push the
+    # agricola/state branch with the checkout credentials. The state pull
+    # request itself is opened with a short-lived GitHub App token minted via
+    # github-sts (authorized by .github/sts/agricola-audit-state.sts.yaml)
+    # because the built-in GITHUB_TOKEN is not allowed to create pull
+    # requests. id-token lets the job request the OIDC token the STS
+    # exchange verifies.
     permissions:
       contents: write
-      pull-requests: write
+      id-token: write
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       STATE_BRANCH: agricola/state
@@ -294,10 +301,16 @@ jobs:
               --report-file "$RUNNER_TEMP/audit-report.json"
           cat "$RUNNER_TEMP/audit-report.json"
 
+      - name: Fetch GitHub token via STS
+        id: sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        with:
+          policy: agricola-audit-state
+
       - name: Ensure state pull request
         uses: ./.github/actions/persist-agricola-state
         with:
-          token: ${{ github.token }}
+          token: ${{ steps.sts.outputs.token }}
           base: ${{ env.DEFAULT_BRANCH }}
           branch: ${{ env.STATE_BRANCH }}
 


### PR DESCRIPTION
## Motivation

We are disabling the org-level **"Allow GitHub Actions to create and approve pull requests"** setting, after which the built-in `GITHUB_TOKEN` can no longer open or approve pull requests. The audit roll-up job opens the `agricola/state` checkpoint PR through `persist-agricola-state` with `github.token`.

## Changes

- Mint a short-lived GitHub App token via STS(`tempoxyz/gh-actions/actions/github-sts`, SHA-pinned) and pass it to `persist-agricola-state` (the composite action is unchanged).
- Replace the roll-up job's `pull-requests: write` with `id-token: write`. `contents: write` stays: `agricola state-transaction` still pushes the state branch with the checkout credentials, and branch pushes are unaffected by the org setting.
- Add `.github/sts/agricola-audit-state.sts.yaml`: subject pinned to this repo's `main` ref with a `job_workflow_ref` claim check on this workflow, granting `contents: write` + `pull_requests: write`.

## Notes

- Sibling PRs migrate `agricola.yml` (same pattern, own policy) and `dependabot.yml`.
- Verify by dispatching **Agricola SDK audit** after merge.

