### PR TITLE
ci(dependabot): approve and merge updates via github-sts

### DIFF
--- a/.github/sts/dependabot.sts.yaml
+++ b/.github/sts/dependabot.sts.yaml
@@ -1,0 +1,18 @@
+# Allow the Dependabot auto-merge workflow to mint a short-lived token that
+# approves and squash-merges Dependabot's patch/minor update PRs. Replaces
+# the built-in GITHUB_TOKEN so the org can turn off "Allow GitHub Actions to
+# create and approve pull requests".
+#
+# pull_request runs carry the bare repo:...:pull_request subject, which any
+# pull_request-triggered workflow in this repo can present, so the claim
+# checks below do the narrowing: the run must have been triggered by
+# dependabot[bot] (a human pushing to the PR branch becomes the actor and is
+# denied) and must be this workflow.
+subject: repo:tempoxyz@211589300/mpp-tools@1255838786:pull_request
+claim_pattern:
+  actor: dependabot\[bot\]
+  actor_id: "49699333"
+  job_workflow_ref: tempoxyz/mpp-tools/\.github/workflows/dependabot\.yml@.+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -5,10 +5,19 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
 
+# The approve and merge steps authenticate with a short-lived GitHub App
+# token minted via github-sts (authorized by .github/sts/dependabot.sts.yaml
+# in the repository the workflow runs against) rather than the built-in
+# GITHUB_TOKEN, which is not allowed to approve pull requests. The built-in
+# token keeps read scopes for the check-watching step; id-token lets the job
+# request the OIDC token the STS exchange verifies. workflow_call callers
+# must grant these same permissions and carry their own dependabot STS
+# policy.
 permissions:
   checks: read
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
+  id-token: write
 
 concurrency:
   group: dependabot-${{ github.repository }}-${{ github.event.pull_request.number }}
@@ -86,13 +95,22 @@ jobs:
           echo "Timed out waiting for pull request checks"
           exit 1
 
+      - name: Fetch GitHub token via STS
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        id: sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        with:
+          policy: dependabot
+
       - name: Approve update
         if: >-
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.sts.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr review "$PR_URL" --approve
 
@@ -101,7 +119,7 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.sts.outputs.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge "$PR_URL" --squash --match-head-commit "$HEAD_SHA"


### PR DESCRIPTION
## Motivation

We are disabling the org-level **"Allow GitHub Actions to create and approve pull requests"** setting, after which the built-in `GITHUB_TOKEN` can no longer open or **approve** pull requests. This is the only workflow in the org that approves PRs with `github.token` (`gh pr review --approve` + `gh pr merge` on Dependabot patch/minor updates).

## Changes

- Mint a short-lived GitHub App token via STS (`tempoxyz/gh-actions/actions/github-sts`, SHA-pinned) and use it for the approve and merge steps. The check-watching step keeps the read-only built-in token.
- Drop the workflow's built-in token to read scopes and add `id-token: write`.
- Add `.github/sts/dependabot.sts.yaml`. `pull_request` runs carry the bare `repo:...:pull_request` OIDC subject, which any PR-triggered workflow in the repo can present, so the policy narrows with claim checks: `actor`/`actor_id` must be `dependabot[bot]` (a human pushing to the PR branch becomes the actor and is denied) and `job_workflow_ref` must be this workflow.

## Things to verify before relying on this

1. **Dependabot-triggered runs and OIDC.** Dependabot-actor `pull_request` runs are permission-restricted like fork PRs; the `permissions:` block lifts scopes, but please confirm a Dependabot PR can actually obtain an OIDC token (`id-token: write`) before flipping the org setting. If it cannot, the fallback is moving this workflow to `pull_request_target` pinned to the base ref.
2. **Verified-human review requirements.** The org recently moved toward requiring verified-human reviews. The STS App's approval will post fine, but on any repo whose ruleset requires human reviews it will not satisfy the requirement — worth confirming what this auto-approve is meant to satisfy on `mpp-tools` and the callers below.

## Downstream callers need follow-ups

This workflow is also consumed via `workflow_call` (pinned by SHA) from **mpp, mpp-rs, mpp-go, mpp-specs, pympp, hermes-mpp, and one private repo** — at runtime the approve/merge there uses each caller's own token, so those repos break identically when the org setting flips. After this merges, each caller needs a follow-up PR that:

1. bumps the pin to the new SHA,
2. grants `checks: read`, `contents: read`, `pull-requests: read`, `id-token: write` on the calling job, and
3. adds its own `.github/sts/dependabot.sts.yaml` (the STS action scopes to the repository the workflow runs against, so the policy lives in the caller).

