### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/actions/setup-conformance/action.yml
+++ b/.github/actions/setup-conformance/action.yml
@@ -22,12 +22,12 @@ runs:
   using: composite
   steps:
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: "3.12"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v7
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
       with:
         version: "0.9.26"
         python-version: "3.12"
@@ -38,7 +38,7 @@ runs:
 
     - name: Setup Node.js
       if: inputs.setup-node == 'true' || inputs.adapter == 'typescript' || inputs.adapter == 'all'
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: "24.5"
         cache: npm
@@ -46,17 +46,17 @@ runs:
 
     - name: Setup Rust
       if: inputs.adapter == 'rust' || inputs.adapter == 'all'
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
 
     - name: Cache Rust dependencies
       if: inputs.adapter == 'rust' || inputs.adapter == 'all'
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       with:
         workspaces: ${{ inputs.conformance-directory }}/adapters/rust -> target
 
     - name: Setup Go
       if: inputs.adapter == 'go' || inputs.adapter == 'all'
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
       with:
         go-version: "1.26.0"
         check-latest: true
@@ -64,7 +64,7 @@ runs:
 
     - name: Setup Java
       if: inputs.adapter == 'java' || inputs.adapter == 'all'
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
       with:
         distribution: temurin
         java-version: "17"
@@ -76,7 +76,7 @@ runs:
 
     - name: Setup Ruby
       if: inputs.adapter == 'ruby' || inputs.adapter == 'all'
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
       with:
         ruby-version: "3.3"
         bundler-cache: ${{ inputs.ruby-bundler-cache }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           python-version: "3.12"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "0.9.26"
           enable-cache: true

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -58,7 +58,7 @@ jobs:
       reason: ${{ steps.select.outputs.reason }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Collect changed files
         if: github.event_name == 'pull_request'
@@ -105,7 +105,7 @@ jobs:
         working-directory: conformance
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup conformance adapter
         uses: ./.github/actions/setup-conformance
@@ -137,7 +137,7 @@ jobs:
 
       - name: Upload vector results
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vector-results-${{ matrix.adapter }}
           path: |
@@ -159,7 +159,7 @@ jobs:
         working-directory: conformance
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup conformance adapter
         uses: ./.github/actions/setup-conformance
@@ -199,7 +199,7 @@ jobs:
 
       - name: Upload flow results
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: flow-results-${{ matrix.adapter }}
           path: |
@@ -217,7 +217,7 @@ jobs:
         working-directory: conformance
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup conformance adapter
         uses: ./.github/actions/setup-conformance
@@ -255,12 +255,12 @@ jobs:
         working-directory: conformance
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Download vector results
         if: needs.changes.outputs.run_conformance == 'true'
         continue-on-error: true
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: vector-results-*
           path: conformance/vector-results
@@ -269,7 +269,7 @@ jobs:
       - name: Download flow results
         if: needs.changes.outputs.run_conformance == 'true'
         continue-on-error: true
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: flow-results-*
           path: conformance/flow-results

--- a/.github/workflows/sdk-conformance-policy.yml
+++ b/.github/workflows/sdk-conformance-policy.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout policy scripts
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: tempoxyz/mpp-tools
           ref: ${{ inputs.default-conformance-ref }}

--- a/.github/workflows/sdk-conformance.yml
+++ b/.github/workflows/sdk-conformance.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout SDK
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: sdk
 
@@ -60,7 +60,7 @@ jobs:
           echo "conformance_ref=$REQUESTED_CONFORMANCE_REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout conformance suite
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: tempoxyz/mpp-tools
           ref: ${{ steps.resolve.outputs.conformance_ref }}


### PR DESCRIPTION
Updating our GitHub Actions to pin them to full-length commit SHAs.