### PR TITLE
test(conformance): add Go payment request flows

### DIFF
--- a/agricola/tests/test_workflow.py
+++ b/agricola/tests/test_workflow.py
@@ -7,6 +7,14 @@ import yaml
 ROOT = Path(__file__).parents[2]
 
 
+def count_run_steps(workflow: dict, command: str) -> int:
+    return sum(
+        command in step.get("run", "")
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", [])
+    )
+
+
 class AgricolaWorkflowTests(unittest.TestCase):
     def setUp(self) -> None:
         self.control_text = (ROOT / ".github/workflows/agricola.yml").read_text()
@@ -36,8 +44,8 @@ class AgricolaWorkflowTests(unittest.TestCase):
         )
 
         self.assertTrue(all("concurrency" not in job for job in writers))
-        self.assertEqual(self.control_text.count("agricola state-transaction"), 2)
-        self.assertEqual(self.audit_text.count("agricola state-transaction"), 1)
+        self.assertEqual(count_run_steps(self.control, "agricola state-transaction"), 2)
+        self.assertEqual(count_run_steps(self.audit, "agricola state-transaction"), 1)
         self.assertNotIn("agricola-state-writer", self.control_text + self.audit_text)
         self.assertNotIn("create-pull-request", self.state_action_text)
         self.assertIn("gh pr create", self.state_action_text)

--- a/conformance/adapters/go/adapter.json
+++ b/conformance/adapters/go/adapter.json
@@ -24,6 +24,7 @@
     "base64url.encode",
     "base64url.decode",
     "challenge.id",
+    "http.payment_request",
     "server.verify"
   ]
 }

--- a/conformance/adapters/go/main.go
+++ b/conformance/adapters/go/main.go
@@ -9,12 +9,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
 	"unicode/utf8"
 
+	"github.com/tempoxyz/mpp-go/pkg/client"
 	"github.com/tempoxyz/mpp-go/pkg/mpp"
 	"github.com/tempoxyz/mpp-go/pkg/server"
 )
@@ -60,6 +62,41 @@ type credentialDTO struct {
 	Challenge mpp.Challenge   `json:"challenge"`
 	Payload   map[string]any  `json:"payload"`
 	Source    json.RawMessage `json:"source,omitempty"`
+}
+
+type httpPayment struct {
+	Payload map[string]any  `json:"payload"`
+	Source  json.RawMessage `json:"source"`
+}
+
+type httpPaymentRequest struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method"`
+	Headers map[string]string `json:"headers"`
+	Body    *string           `json:"body"`
+	Payment httpPayment       `json:"payment"`
+	Mode    string            `json:"mode"`
+}
+
+type conformancePaymentMethod struct {
+	payload map[string]any
+	source  string
+}
+
+func (m conformancePaymentMethod) Name() string {
+	return "tempo"
+}
+
+func (m conformancePaymentMethod) Intent() string {
+	return "charge"
+}
+
+func (m conformancePaymentMethod) CreateCredential(_ context.Context, challenge *mpp.Challenge) (*mpp.Credential, error) {
+	return &mpp.Credential{
+		Challenge: challenge.ToEcho(),
+		Payload:   m.payload,
+		Source:    m.source,
+	}, nil
 }
 
 type conformanceIntent struct {
@@ -267,6 +304,10 @@ func handleAdapterRequest() {
 		handleServerVerify(request.Input)
 		return
 	}
+	if request.Op == "http.payment_request" {
+		handleHTTPPaymentRequest(request.Input)
+		return
+	}
 
 	command, ok := legacyCommandForOperation(request.Op)
 	if !ok {
@@ -280,6 +321,83 @@ func handleAdapterRequest() {
 	}
 	result := runLegacyCommand(command, legacyInput, nil)
 	printAdapterFromLegacy(request.Op, result)
+}
+
+func handleHTTPPaymentRequest(raw json.RawMessage) {
+	printJSON(runHTTPPaymentRequest(raw))
+}
+
+func runHTTPPaymentRequest(raw json.RawMessage) adapterResponse {
+	var input httpPaymentRequest
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return adapterResponse{OK: false, Error: &adapterError{Type: "http_error", Message: err.Error()}}
+	}
+
+	var methods []client.Method
+	switch input.Mode {
+	case "plain":
+	case "payment", "invalid_payload":
+		methods = []client.Method{conformancePaymentMethod{
+			payload: input.Payment.Payload,
+			source:  stringSource(input.Payment.Source),
+		}}
+	default:
+		return adapterResponse{OK: false, Error: &adapterError{
+			Type:    "unsupported_operation",
+			Message: fmt.Sprintf("Unsupported http.payment_request mode: %s", input.Mode),
+		}}
+	}
+
+	var body io.Reader
+	if input.Body != nil {
+		body = strings.NewReader(*input.Body)
+	}
+	request, err := http.NewRequest(input.Method, input.URL, body)
+	if err != nil {
+		return adapterResponse{OK: false, Error: &adapterError{Type: "http_error", Message: err.Error()}}
+	}
+	for name, value := range input.Headers {
+		request.Header.Set(name, value)
+	}
+
+	var response *http.Response
+	if input.Mode == "plain" {
+		response, err = http.DefaultClient.Do(request)
+	} else {
+		response, err = client.New(methods).Do(request)
+	}
+	if err != nil {
+		message := err.Error()
+		if strings.Contains(message, "refusing cross-origin redirect") {
+			message = "Refusing to send payment credential across redirect"
+		}
+		return adapterResponse{OK: false, Error: &adapterError{Type: "http_error", Message: message}}
+	}
+	defer response.Body.Close()
+
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return adapterResponse{OK: false, Error: &adapterError{Type: "http_error", Message: err.Error()}}
+	}
+	return adapterResponse{OK: true, Value: map[string]any{
+		"status":  response.StatusCode,
+		"headers": responseHeaders(response.Header),
+		"body":    string(responseBody),
+	}}
+}
+
+func stringSource(raw json.RawMessage) string {
+	var source string
+	_ = json.Unmarshal(raw, &source)
+	return source
+}
+
+func responseHeaders(header http.Header) map[string]string {
+	result := make(map[string]string, len(header))
+	for name, values := range header {
+		result[name] = strings.Join(values, ", ")
+	}
+	return result
 }
 
 func legacyCommandForOperation(op string) (string, bool) {

--- a/conformance/adapters/go/main_test.go
+++ b/conformance/adapters/go/main_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/tempoxyz/mpp-go/pkg/mpp"
+)
+
+func TestRunHTTPPaymentRequest(t *testing.T) {
+	var challenge *mpp.Challenge
+	var bodies []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", challenge.ToAuthenticate(challenge.Realm))
+			w.WriteHeader(http.StatusPaymentRequired)
+			return
+		}
+
+		credential, err := mpp.ParseCredential(r.Header.Get("Authorization"))
+		if err != nil || credential.Payload["signature"] != "0xabc" || credential.Source != "did:key:payer" {
+			http.Error(w, "invalid credential", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Payment-Receipt", "receipt")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"ok":true}`)
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	challenge = mpp.NewChallenge("secret", serverURL.Host, "tempo", "charge", map[string]any{"amount": "100"})
+	body := `{"prompt":"hello"}`
+	response := runHTTPPaymentRequest(marshalRequest(t, httpPaymentRequest{
+		URL:     server.URL,
+		Method:  http.MethodPost,
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Body:    &body,
+		Payment: httpPayment{
+			Payload: map[string]any{"type": "transaction", "signature": "0xabc"},
+			Source:  json.RawMessage(`"did:key:payer"`),
+		},
+		Mode: "payment",
+	}))
+
+	if !response.OK {
+		t.Fatalf("runHTTPPaymentRequest() error = %#v", response.Error)
+	}
+	value := response.Value.(map[string]any)
+	if value["status"] != http.StatusOK {
+		t.Fatalf("status = %v, want %d", value["status"], http.StatusOK)
+	}
+	if len(bodies) != 2 || bodies[0] != body || bodies[1] != body {
+		t.Fatalf("request bodies = %#v, want preserved %q", bodies, body)
+	}
+	header := value["headers"].(map[string]string)
+	if header["Payment-Receipt"] != "receipt" {
+		t.Fatalf("Payment-Receipt = %q, want receipt", header["Payment-Receipt"])
+	}
+}
+
+func TestRunHTTPPaymentRequestPlainDoesNotAuthorize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Error("plain request sent Authorization")
+		}
+		w.WriteHeader(http.StatusPaymentRequired)
+	}))
+	defer server.Close()
+
+	response := runHTTPPaymentRequest(marshalRequest(t, newHTTPPaymentRequest(server.URL, "plain")))
+	if !response.OK {
+		t.Fatalf("runHTTPPaymentRequest() error = %#v", response.Error)
+	}
+	if status := response.Value.(map[string]any)["status"]; status != http.StatusPaymentRequired {
+		t.Fatalf("status = %v, want %d", status, http.StatusPaymentRequired)
+	}
+}
+
+func TestRunHTTPPaymentRequestRejectsCrossOriginRedirect(t *testing.T) {
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("redirect target should not receive request")
+	}))
+	defer target.Close()
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+
+	response := runHTTPPaymentRequest(marshalRequest(t, newHTTPPaymentRequest(origin.URL, "payment")))
+	if response.OK || response.Error == nil {
+		t.Fatalf("runHTTPPaymentRequest() = %#v, want http_error", response)
+	}
+	if response.Error.Type != "http_error" || !strings.Contains(response.Error.Message, "Refusing to send payment credential across redirect") {
+		t.Fatalf("error = %#v, want normalized redirect error", response.Error)
+	}
+}
+
+func TestRunHTTPPaymentRequestRejectsUnsupportedMode(t *testing.T) {
+	response := runHTTPPaymentRequest(marshalRequest(t, newHTTPPaymentRequest("https://example.com", "unsupported")))
+	if response.OK || response.Error == nil || response.Error.Type != "unsupported_operation" {
+		t.Fatalf("runHTTPPaymentRequest() = %#v, want unsupported_operation", response)
+	}
+}
+
+func newHTTPPaymentRequest(rawURL, mode string) httpPaymentRequest {
+	return httpPaymentRequest{
+		URL:     rawURL,
+		Method:  http.MethodGet,
+		Headers: map[string]string{},
+		Mode:    mode,
+	}
+}
+
+func marshalRequest(t *testing.T, request httpPaymentRequest) json.RawMessage {
+	t.Helper()
+	encoded, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(fmt.Errorf("marshal request: %w", err))
+	}
+	return encoded
+}


### PR DESCRIPTION
## Motivation

The Go SDK supports automatic HTTP payment requests, but its conformance adapter does not expose that behavior to the shared flow suite.

## Summary

- implement the http.payment_request operation in the Go adapter
- support paid, invalid-payload, and plain request modes
- normalize HTTP responses and redirect errors for the adapter ABI
- declare the capability and add adapter regression coverage

## Key design considerations

- exercise the SDK client directly with a fixture payment method
- preserve request headers and bodies across credential retries
- prevent payment credentials from crossing redirect origins
