### PR TITLE
chore: update GitHub STS action

### DIFF
--- a/.github/workflows/agricola-audit.yml
+++ b/.github/workflows/agricola-audit.yml
@@ -303,7 +303,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: agricola-audit-state
 

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: agricola-state
 
@@ -538,7 +538,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: agricola-state
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -100,7 +100,7 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
         with:
           policy: dependabot
 


### PR DESCRIPTION
## Summary

- Pin the GitHub STS action to `8819cf80bdcb39c36c34700e3f2ecc08bde54f23`.
- Route post-job token revocation through STS so GitHub and the D1 ownership ledger are updated together.
- Retain the action’s direct GitHub revocation fallback and ledger reconciliation.

Previous action revisions revoked tokens directly at GitHub, leaving their STS rows marked active until expiration. This pin includes tempoxyz/gh-actions#73 and the paired tempoxyz/github-sts#39 service behavior.

## Validation

- `actionlint` on the changed workflows
- `git diff --check`