### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/actions/setup-conformance/action.yml
+++ b/.github/actions/setup-conformance/action.yml
@@ -27,7 +27,7 @@ runs:
         python-version: "3.12"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+      uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
       with:
         version: "0.9.26"
         python-version: "3.12"
@@ -46,11 +46,11 @@ runs:
 
     - name: Setup Rust
       if: inputs.adapter == 'rust' || inputs.adapter == 'all'
-      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c
+      uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
     - name: Cache Rust dependencies
       if: inputs.adapter == 'rust' || inputs.adapter == 'all'
-      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@6f436eb3a168279692739e8c0c9fdb52b94bfae7
       with:
         workspaces: ${{ inputs.conformance-directory }}/adapters/rust -> target
 

--- a/.github/actions/setup-conformance/action.yml
+++ b/.github/actions/setup-conformance/action.yml
@@ -27,7 +27,7 @@ runs:
         python-version: "3.12"
 
     - name: Install uv
-      uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+      uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
       with:
         version: "0.9.26"
         python-version: "3.12"
@@ -46,11 +46,11 @@ runs:
 
     - name: Setup Rust
       if: inputs.adapter == 'rust' || inputs.adapter == 'all'
-      uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+      uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
 
     - name: Cache Rust dependencies
       if: inputs.adapter == 'rust' || inputs.adapter == 'all'
-      uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+      uses: tempoxyz/gh-actions/vendor/Swatinem/rust-cache@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
       with:
         workspaces: ${{ inputs.conformance-directory }}/adapters/rust -> target
 

--- a/.github/workflows/agricola-audit.yml
+++ b/.github/workflows/agricola-audit.yml
@@ -303,7 +303,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
         with:
           policy: agricola-audit-state
 

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
         with:
           policy: agricola-state
 
@@ -538,7 +538,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
         with:
           policy: agricola-state
 

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -242,7 +242,7 @@ jobs:
             --output .agricola/revision.md
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           version: "0.9.26"
 
@@ -372,7 +372,7 @@ jobs:
 
       - name: Setup uv
         if: steps.patch.outputs.has-changes == 'true'
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           version: "0.9.26"
 

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -242,7 +242,7 @@ jobs:
             --output .agricola/revision.md
 
       - name: Setup uv
-        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           version: "0.9.26"
 
@@ -372,7 +372,7 @@ jobs:
 
       - name: Setup uv
         if: steps.patch.outputs.has-changes == 'true'
-        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           version: "0.9.26"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           version: "0.9.26"
           python-version: "3.12"
@@ -81,7 +81,7 @@ jobs:
           python-version: "3.12"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           version: "0.9.26"
           enable-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup uv
-        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           version: "0.9.26"
           python-version: "3.12"
@@ -81,7 +81,7 @@ jobs:
           python-version: "3.12"
 
       - name: Setup uv
-        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@6f436eb3a168279692739e8c0c9fdb52b94bfae7
+        uses: tempoxyz/gh-actions/vendor/astral-sh/setup-uv@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
         with:
           version: "0.9.26"
           enable-cache: true

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -100,7 +100,7 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23 # main
+        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
         with:
           policy: dependabot
 


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `Swatinem/rust-cache` | [`tempoxyz/gh-actions/vendor/Swatinem/rust-cache`](https://github.com/tempoxyz/gh-actions/tree/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor/Swatinem/rust-cache) |
| `astral-sh/setup-uv` | [`tempoxyz/gh-actions/vendor/astral-sh/setup-uv`](https://github.com/tempoxyz/gh-actions/tree/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor/astral-sh/setup-uv) |
| `dtolnay/rust-toolchain` | [`tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain`](https://github.com/tempoxyz/gh-actions/tree/3626124474a987bc74b41fc7ae65b2e23f8e4e4e/vendor/dtolnay/rust-toolchain) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 0 -> 0, zizmor 76 -> 75).

## Pin comments

- `# main` comments next to full-SHA pins of tempoxyz actions are removed: they claim the pin tracks `main`, which stops being true as soon as `main` moves and trips zizmor's `ref-version-mismatch` audit. The pinned commits are unchanged.
