### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/actions/setup-conformance/action.yml
+++ b/.github/actions/setup-conformance/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Setup Ruby
       if: inputs.adapter == 'ruby' || inputs.adapter == 'all'
-      uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1
+      uses: tempoxyz/gh-actions/vendor/ruby/setup-ruby@b411ce7fe18d0775ae614ad5c4b873c768364979
       with:
         ruby-version: "3.3"
         bundler-cache: ${{ inputs.ruby-bundler-cache }}

--- a/.github/workflows/agricola-audit.yml
+++ b/.github/workflows/agricola-audit.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Compare SDK implementation to canonical mppx
         id: semantic
         continue-on-error: true
-        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
+        uses: tempoxyz/gh-actions/vendor/openai/codex-action@b411ce7fe18d0775ae614ad5c4b873c768364979
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .github/agricola/audit.md

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -247,7 +247,7 @@ jobs:
           version: "0.9.26"
 
       - name: Generate downstream changes
-        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1
+        uses: tempoxyz/gh-actions/vendor/openai/codex-action@b411ce7fe18d0775ae614ad5c4b873c768364979
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: .agricola/control/.github/agricola/propagate.md

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Read Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: tempoxyz/gh-actions/vendor/dependabot/fetch-metadata@b411ce7fe18d0775ae614ad5c4b873c768364979
 
       - name: Wait for checks
         if: >-


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/b411ce7fe18d0775ae614ad5c4b873c768364979/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `dependabot/fetch-metadata` | [`tempoxyz/gh-actions/vendor/dependabot/fetch-metadata`](https://github.com/tempoxyz/gh-actions/tree/b411ce7fe18d0775ae614ad5c4b873c768364979/vendor/dependabot/fetch-metadata) |
| `openai/codex-action` | [`tempoxyz/gh-actions/vendor/openai/codex-action`](https://github.com/tempoxyz/gh-actions/tree/b411ce7fe18d0775ae614ad5c4b873c768364979/vendor/openai/codex-action) |
| `ruby/setup-ruby` | [`tempoxyz/gh-actions/vendor/ruby/setup-ruby`](https://github.com/tempoxyz/gh-actions/tree/b411ce7fe18d0775ae614ad5c4b873c768364979/vendor/ruby/setup-ruby) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 0 -> 0, zizmor 75 -> 75).
