### PR TITLE
Pin GitHub STS POST action

### DIFF
--- a/.github/workflows/agricola-audit.yml
+++ b/.github/workflows/agricola-audit.yml
@@ -303,7 +303,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad
         with:
           policy: agricola-audit-state
 

--- a/.github/workflows/agricola.yml
+++ b/.github/workflows/agricola.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad
         with:
           policy: agricola-state
 
@@ -538,7 +538,7 @@ jobs:
 
       - name: Fetch GitHub token via STS
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad
         with:
           policy: agricola-state
 

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -100,7 +100,7 @@ jobs:
           steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
           steps.metadata.outputs.update-type == 'version-update:semver-minor'
         id: sts
-        uses: tempoxyz/gh-actions/actions/github-sts@8819cf80bdcb39c36c34700e3f2ecc08bde54f23
+        uses: tempoxyz/gh-actions/actions/github-sts@c0292122e255def866c64c55e5844d1e7d5fe7ad
         with:
           policy: dependabot
 


### PR DESCRIPTION
## Summary

- pin all GitHub STS action uses to tempoxyz/gh-actions@c0292122e255def866c64c55e5844d1e7d5fe7ad
- use the action version that sends `POST /sts/exchange`
- preserve all existing scopes, policies, TTLs, and workflow behavior

This is part of the coordinated organization-wide rollout required before retiring legacy GET exchanges.

## Validation

- mechanical pin-only update; repository CI is the behavioral validation