### PR TITLE
fix(conformance): support optional Rust challenge headers

### DIFF
--- a/conformance/README.md
+++ b/conformance/README.md
@@ -43,7 +43,7 @@ Vectors live in `vectors/` and cover the core protocol surface:
 | `authorization.json` | Parsing and formatting `Authorization: Payment ...` credential headers. The credential is base64url-encoded JSON containing `challenge`, `payload`, and optional `source`. |
 | `receipt.json` | Parsing and formatting `Payment-Receipt: ...` headers. Base64url-encoded JSON with `status`, `method`, `timestamp`, `reference`. |
 | `base64url.json` | RFC 4648 §5 encoding: no padding, URL-safe alphabet (`-`/`_` instead of `+`/`/`). |
-| `challenge-id.json` | Deterministic challenge ID generation via HMAC-SHA256. Input is pipe-delimited (`realm\|method\|intent\|canonicalized_request\|expires\|digest\|opaque`), output is unpadded base64url. |
+| `challenge-id.json` | Deterministic challenge ID generation via HMAC-SHA256. Input is pipe-delimited (`realm\|method\|intent\|canonicalized_request\|expires\|digest\|[header\|]opaque`); a non-default credential header is inserted before `opaque`. Output is unpadded base64url. |
 | `tempo-proof.json` | EIP-712 typed-data shape for zero-amount Tempo proof credentials. Binds `challengeId` and `realm` under domain `MPP` version `2`. |
 
 Each vector file contains **scenarios** — individual test cases with a name, description, tags, and expected inputs/outputs:

--- a/conformance/adapters/go/main.go
+++ b/conformance/adapters/go/main.go
@@ -278,6 +278,7 @@ func handleGenerateChallengeID(input string) {
 		mapField(data, "request"),
 		stringField(data, "expires"),
 		stringField(data, "digest"),
+		stringField(data, "header"),
 		stringField(data, "opaque"),
 	)
 	if err != nil {
@@ -658,22 +659,26 @@ func parseConformanceReceipt(header string) (*mpp.Receipt, error) {
 // string placed directly in the pipe-delimited HMAC input, which differs from
 // the library's map[string]string encoding. Once the spec settles on a single
 // encoding this can be replaced with mpp.GenerateChallengeID.
-func generateConformanceChallengeID(secretKey, realm, method, intent string, request map[string]any, expires, digest, opaque string) (string, error) {
+func generateConformanceChallengeID(secretKey, realm, method, intent string, request map[string]any, expires, digest, header, opaque string) (string, error) {
 	if len([]byte(secretKey)) < minimumSecretKeyBytes {
 		return "", fmt.Errorf("secretKey must be at least %d bytes", minimumSecretKeyBytes)
 	}
 
 	requestB64, _ := encodeJSONBase64URL(request)
 
-	input := strings.Join([]string{
+	inputParts := []string{
 		realm,
 		method,
 		intent,
 		requestB64,
 		expires,
 		digest,
-		opaque,
-	}, "|")
+	}
+	if header != "" && !strings.EqualFold(header, "Authorization") {
+		inputParts = append(inputParts, header)
+	}
+	inputParts = append(inputParts, opaque)
+	input := strings.Join(inputParts, "|")
 
 	mac := hmac.New(sha256.New, []byte(secretKey))
 	mac.Write([]byte(input))

--- a/conformance/adapters/java/src/main/java/xyz/tempo/mpp/conformance/Adapter.java
+++ b/conformance/adapters/java/src/main/java/xyz/tempo/mpp/conformance/Adapter.java
@@ -329,9 +329,10 @@ public final class Adapter {
         Map<String, Object> request = requireMap(data.get("request"), "request", "generation_error");
         String expires = optionalString(data, "expires", "generation_error");
         String digest = optionalString(data, "digest", "generation_error");
+        String header = optionalString(data, "header", "generation_error");
         String opaque = optionalString(data, "opaque", "generation_error");
 
-        if (opaque == null) {
+        if (header == null && opaque == null) {
             try {
                 return ChallengeId.generate(
                     secretKey,
@@ -349,15 +350,19 @@ public final class Adapter {
         }
 
         String requestB64 = encodeJsonBase64Url(request, "generation_error");
-        String input = String.join("|",
+        List<String> inputParts = new ArrayList<>(List.of(
             requiredString(data, "realm", "generation_error", true),
             requiredString(data, "method", "generation_error", true),
             requiredString(data, "intent", "generation_error", true),
             requestB64,
             expires == null ? "" : expires,
-            digest == null ? "" : digest,
-            opaque
-        );
+            digest == null ? "" : digest
+        ));
+        if (header != null && !header.equalsIgnoreCase("Authorization")) {
+            inputParts.add(header);
+        }
+        inputParts.add(opaque == null ? "" : opaque);
+        String input = String.join("|", inputParts);
 
         try {
             Mac mac = Mac.getInstance("HmacSHA256");

--- a/conformance/adapters/python/adapter.py
+++ b/conformance/adapters/python/adapter.py
@@ -57,20 +57,23 @@ def canonical_json(value) -> str:
     return json.dumps(value, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
 
 
-def generate_conformance_challenge_id(*, secret_key: str, realm: str, method: str, intent: str, request, expires: str | None = None, digest: str | None = None, opaque: str | None = None) -> str:
+def generate_conformance_challenge_id(*, secret_key: str, realm: str, method: str, intent: str, request, expires: str | None = None, digest: str | None = None, header: str | None = None, opaque: str | None = None) -> str:
     if len(secret_key.encode("utf-8")) < MINIMUM_SECRET_KEY_BYTES:
         raise ValueError(f"secretKey must be at least {MINIMUM_SECRET_KEY_BYTES} bytes")
 
     request_b64 = base64.urlsafe_b64encode(canonical_json(request or {}).encode("utf-8")).decode("ascii").rstrip("=")
-    payload = "|".join([
+    payload_parts = [
         realm,
         method,
         intent,
         request_b64,
         expires or "",
         digest or "",
-        opaque or "",
-    ])
+    ]
+    if header and header.lower() != "authorization":
+        payload_parts.append(header)
+    payload_parts.append(opaque or "")
+    payload = "|".join(payload_parts)
     signature = hmac.new(secret_key.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).digest()
     return base64.urlsafe_b64encode(signature).decode("ascii").rstrip("=")
 
@@ -439,6 +442,7 @@ def main():
                 request=params.get("request", {}),
                 expires=params.get("expires"),
                 digest=params.get("digest"),
+                header=params.get("header"),
                 opaque=params.get("opaque"),
             )
             print(json.dumps(success(result)))

--- a/conformance/adapters/ruby/adapter.rb
+++ b/conformance/adapters/ruby/adapter.rb
@@ -67,9 +67,12 @@ def generate_conformance_challenge_id(params)
     params["intent"] || "",
     request_b64,
     params["expires"] || "",
-    params["digest"] || "",
-    params["opaque"] || ""
-  ].join("|")
+    params["digest"] || ""
+  ]
+  header = params["header"]
+  payload << header if header && !header.casecmp?("Authorization")
+  payload << (params["opaque"] || "")
+  payload = payload.join("|")
   digest = OpenSSL::HMAC.digest("SHA256", secret_key.encode("UTF-8"), payload.encode("UTF-8"))
   base64url_encode(digest)
 end

--- a/conformance/adapters/rust/src/main.rs
+++ b/conformance/adapters/rust/src/main.rs
@@ -329,6 +329,7 @@ fn handle_generate_challenge_id(input: &str) {
                 .unwrap_or(serde_json::json!({}));
             let expires = opt_str_field(&params, "expires");
             let digest = opt_str_field(&params, "digest");
+            let header = opt_str_field(&params, "header");
             let opaque = opt_str_field(&params, "opaque");
 
             let challenge_id_params = ChallengeIdParams {
@@ -339,6 +340,7 @@ fn handle_generate_challenge_id(input: &str) {
                 request: &request,
                 expires: expires.as_deref(),
                 digest: digest.as_deref(),
+                header: header.as_deref(),
                 opaque: opaque.as_deref(),
             };
 
@@ -553,6 +555,7 @@ struct ChallengeIdParams<'a> {
     request: &'a Value,
     expires: Option<&'a str>,
     digest: Option<&'a str>,
+    header: Option<&'a str>,
     opaque: Option<&'a str>,
 }
 
@@ -569,16 +572,22 @@ fn generate_conformance_challenge_id(params: ChallengeIdParams<'_>) -> Result<St
 
     let request_json = stable_json(params.request).map_err(|e| e.to_string())?;
     let request_b64 = base64url_encode(request_json.as_bytes());
-    let hmac_input = [
+    let mut hmac_input = vec![
         params.realm,
         params.method,
         params.intent,
         &request_b64,
         params.expires.unwrap_or(""),
         params.digest.unwrap_or(""),
-        params.opaque.unwrap_or(""),
-    ]
-    .join("|");
+    ];
+    if let Some(header) = params
+        .header
+        .filter(|header| !header.eq_ignore_ascii_case("Authorization"))
+    {
+        hmac_input.push(header);
+    }
+    hmac_input.push(params.opaque.unwrap_or(""));
+    let hmac_input = hmac_input.join("|");
 
     let mut mac = HmacSha256::new_from_slice(params.secret_key.as_bytes())
         .expect("HMAC can take key of any size");

--- a/conformance/adapters/rust/src/main.rs
+++ b/conformance/adapters/rust/src/main.rs
@@ -4,6 +4,7 @@ use mpp::protocol::core::{
     format_www_authenticate, parse_authorization, parse_receipt, parse_www_authenticate,
     Base64UrlJson, ChallengeEcho, PaymentChallenge, PaymentCredential, Receipt,
 };
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{json, Value};
 use sha2::Sha256;
 use std::io::{self, Read, Write};
@@ -99,6 +100,36 @@ fn opaque_to_json(opaque: &Base64UrlJson) -> Result<Value, String> {
     }
 }
 
+// SDK checkout CI can add optional fields before the pinned release has them.
+// Use the SDK's Serde representation instead of version-specific struct literals:
+// mpp 0.11 ignores `header`, while newer SDKs preserve it (or default to None).
+fn challenge_from_json<T: DeserializeOwned>(value: &Value) -> Result<T, String> {
+    let request = Base64UrlJson::from_value(&value.get("request").cloned().unwrap_or(json!({})))
+        .map_err(|e| e.to_string())?;
+    let opaque = opt_base64url_json_field(value, "opaque")?;
+    serde_json::from_value(json!({
+        "id": str_field(value, "id"),
+        "realm": str_field(value, "realm"),
+        "method": str_field(value, "method"),
+        "intent": str_field(value, "intent"),
+        "request": request,
+        "expires": opt_str_field(value, "expires"),
+        "description": opt_str_field(value, "description"),
+        "digest": opt_str_field(value, "digest"),
+        "opaque": opaque,
+        "header": opt_str_field(value, "header"),
+    }))
+    .map_err(|e| e.to_string())
+}
+
+fn copy_header(value: &impl Serialize, object: &mut Value) -> Result<(), String> {
+    let serialized = serde_json::to_value(value).map_err(|e| e.to_string())?;
+    if let Some(header) = serialized.get("header").filter(|header| !header.is_null()) {
+        object["header"] = header.clone();
+    }
+    Ok(())
+}
+
 fn challenge_to_json(challenge: &PaymentChallenge) -> Result<Value, String> {
     let request_decoded = challenge
         .request
@@ -127,6 +158,7 @@ fn challenge_to_json(challenge: &PaymentChallenge) -> Result<Value, String> {
             opaque_to_json(opaque).map_err(|e| format!("Invalid JSON in opaque: {}", e))?;
     }
 
+    copy_header(challenge, &mut obj)?;
     Ok(obj)
 }
 
@@ -158,6 +190,7 @@ fn credential_to_json(credential: &PaymentCredential) -> Result<Value, String> {
     if let Some(ref opaque) = credential.challenge.opaque {
         challenge_obj["opaque"] = opaque_to_json(opaque)?;
     }
+    copy_header(&credential.challenge, &mut challenge_obj)?;
 
     let mut obj = json!({
         "challenge": challenge_obj,
@@ -206,31 +239,12 @@ fn handle_format_www_authenticate(input: &str) {
                 print_error("id must not be empty", "format_error");
                 return;
             }
-            let request_obj = value.get("request").cloned().unwrap_or(json!({}));
-            let request_b64 = match Base64UrlJson::from_value(&request_obj) {
-                Ok(b64) => b64,
+            let challenge: PaymentChallenge = match challenge_from_json(&value) {
+                Ok(challenge) => challenge,
                 Err(e) => {
-                    print_error(&e.to_string(), "format_error");
+                    print_error(&e, "format_error");
                     return;
                 }
-            };
-
-            let challenge = PaymentChallenge {
-                id,
-                realm: str_field(&value, "realm"),
-                method: str_field(&value, "method").into(),
-                intent: str_field(&value, "intent").into(),
-                request: request_b64,
-                expires: opt_str_field(&value, "expires"),
-                description: opt_str_field(&value, "description"),
-                digest: opt_str_field(&value, "digest"),
-                opaque: match opt_base64url_json_field(&value, "opaque") {
-                    Ok(opaque) => opaque,
-                    Err(e) => {
-                        print_error(&e, "format_error");
-                        return;
-                    }
-                },
             };
 
             match format_www_authenticate(&challenge) {
@@ -246,30 +260,12 @@ fn handle_format_authorization(input: &str) {
     match serde_json::from_str::<Value>(input) {
         Ok(value) => {
             let challenge_val = value.get("challenge").cloned().unwrap_or(json!({}));
-            let request_obj = challenge_val.get("request").cloned().unwrap_or(json!({}));
-            let request_b64 = match Base64UrlJson::from_value(&request_obj) {
-                Ok(b64) => b64,
+            let challenge_echo: ChallengeEcho = match challenge_from_json(&challenge_val) {
+                Ok(challenge) => challenge,
                 Err(e) => {
-                    print_error(&e.to_string(), "format_error");
+                    print_error(&e, "format_error");
                     return;
                 }
-            };
-
-            let challenge_echo = ChallengeEcho {
-                id: str_field(&challenge_val, "id"),
-                realm: str_field(&challenge_val, "realm"),
-                method: str_field(&challenge_val, "method").into(),
-                intent: str_field(&challenge_val, "intent").into(),
-                request: request_b64,
-                expires: opt_str_field(&challenge_val, "expires"),
-                digest: opt_str_field(&challenge_val, "digest"),
-                opaque: match opt_base64url_json_field(&challenge_val, "opaque") {
-                    Ok(opaque) => opaque,
-                    Err(e) => {
-                        print_error(&e, "format_error");
-                        return;
-                    }
-                },
             };
 
             let payload_val = value.get("payload").cloned().unwrap_or(json!({}));

--- a/conformance/golden/adapter.ts
+++ b/conformance/golden/adapter.ts
@@ -125,6 +125,7 @@ function generateConformanceChallengeId(params: {
 	request?: Record<string, unknown>
 	expires?: string
 	digest?: string
+	header?: string
 	opaque?: string
 }): string {
 	if (Buffer.byteLength(params.secretKey, 'utf8') < minimumSecretKeyBytes)
@@ -139,9 +140,11 @@ function generateConformanceChallengeId(params: {
 		requestB64,
 		params.expires ?? '',
 		params.digest ?? '',
-		params.opaque ?? '',
-	].join('|')
-	return createHmac('sha256', params.secretKey).update(payload).digest('base64url')
+	]
+	if (params.header && params.header.toLowerCase() !== 'authorization')
+		payload.push(params.header)
+	payload.push(params.opaque ?? '')
+	return createHmac('sha256', params.secretKey).update(payload.join('|')).digest('base64url')
 }
 
 async function verifyStripeExternalIdBinding(input: {

--- a/conformance/schemas/protocol.schema.json
+++ b/conformance/schemas/protocol.schema.json
@@ -53,7 +53,7 @@
         "expires": { "type": "string", "format": "date-time" },
         "description": { "type": "string" },
         "digest": { "type": "string" },
-        "header": { "type": "string" },
+        "header": { "type": "string", "minLength": 1 },
         "opaque": { "type": "string" }
       }
     },
@@ -123,6 +123,7 @@
         "expires": { "type": "string" },
         "description": { "type": "string" },
         "digest": { "type": "string" },
+        "header": { "type": "string", "minLength": 1 },
         "opaque": { "type": "string" }
       }
     },

--- a/conformance/schemas/protocol.schema.json
+++ b/conformance/schemas/protocol.schema.json
@@ -53,6 +53,7 @@
         "expires": { "type": "string", "format": "date-time" },
         "description": { "type": "string" },
         "digest": { "type": "string" },
+        "header": { "type": "string" },
         "opaque": { "type": "string" }
       }
     },

--- a/conformance/scripts/test_vector_runner.py
+++ b/conformance/scripts/test_vector_runner.py
@@ -80,6 +80,18 @@ class VectorRunnerHelperTest(unittest.TestCase):
         self.assertFalse(applies)
         self.assertEqual(reason, "python@0.9.1 does not satisfy >0.9.1")
 
+    def test_scenario_version_constraint_excludes_last_unsupported_release(self) -> None:
+        scenario = {"sdkVersions": {"rust": ">0.12.0"}}
+        adapter = AdapterConfig(name="rust", command=["adapter"], capabilities=[])
+
+        for version, expected in (("0.12.0", False), ("0.12.1", True)):
+            with self.subTest(version=version):
+                runner = VectorRunner(
+                    output_format="json", sdk_version_resolver=lambda _: version
+                )
+                applies, _ = runner.scenario_version_applies(scenario, adapter)
+                self.assertEqual(applies, expected)
+
     def test_scenario_version_constraint_ignores_unspecified_adapter(self) -> None:
         scenario = {"sdkVersions": {"rust": ">=0.12.0"}}
 

--- a/conformance/vectors/authorization.json
+++ b/conformance/vectors/authorization.json
@@ -9,10 +9,10 @@
   "scenarios": [
     {
       "name": "credential_with_payment_authorization_header",
-      "description": "Preserves the optional header in the Rust SDK 0.12+ challenge echo",
+      "description": "Preserves the optional header in Rust SDK challenge echoes after 0.12.0",
       "tags": ["happy-path", "optional-fields"],
       "adapters": ["rust"],
-      "sdkVersions": { "rust": ">=0.12.0" },
+      "sdkVersions": { "rust": ">0.12.0" },
       "object": {
         "challenge": {
           "id": "ch_header",

--- a/conformance/vectors/authorization.json
+++ b/conformance/vectors/authorization.json
@@ -8,6 +8,26 @@
   },
   "scenarios": [
     {
+      "name": "credential_with_payment_authorization_header",
+      "description": "Preserves the optional header in the Rust SDK 0.12+ challenge echo",
+      "tags": ["happy-path", "optional-fields"],
+      "adapters": ["rust"],
+      "sdkVersions": { "rust": ">=0.12.0" },
+      "object": {
+        "challenge": {
+          "id": "ch_header",
+          "realm": "api.example.com",
+          "method": "tempo",
+          "intent": "charge",
+          "request": {},
+          "header": "Payment-Authorization"
+        },
+        "payload": {}
+      },
+      "wire": "Payment eyJjaGFsbGVuZ2UiOnsiaWQiOiJjaF9oZWFkZXIiLCJyZWFsbSI6ImFwaS5leGFtcGxlLmNvbSIsIm1ldGhvZCI6InRlbXBvIiwiaW50ZW50IjoiY2hhcmdlIiwicmVxdWVzdCI6ImUzMCIsImhlYWRlciI6IlBheW1lbnQtQXV0aG9yaXphdGlvbiJ9LCJwYXlsb2FkIjp7fX0",
+      "tests": { "parse": true, "format": true, "roundtrip": true }
+    },
+    {
       "name": "basic_credential",
       "description": "Minimal credential with required fields",
       "tags": ["happy-path", "required-fields"],

--- a/conformance/vectors/challenge-id.json
+++ b/conformance/vectors/challenge-id.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0.0",
   "spec_ref": "draft-ietf-httpauth-payment \u00a75.1.1",
-  "description": "Challenge ID generation using HMAC-SHA256. HMAC input format: realm|method|intent|canonicalized_request|expires|digest|opaque (pipe-delimited). Output: base64url(HMAC-SHA256(secretKey, input), no padding).",
+  "description": "Challenge ID generation using HMAC-SHA256. HMAC input format: realm|method|intent|canonicalized_request|expires|digest|[header|]opaque (pipe-delimited); a non-default credential header is inserted before opaque. Output: base64url(HMAC-SHA256(secretKey, input), no padding).",
   "commands": {
     "generate": "generate-challenge-id"
   },
@@ -85,6 +85,38 @@
         "opaque": "trace-123"
       },
       "expected": "1XJ-Ti0DACNe3E1zHvwH6OdnKlhUx6xKxDbhJyexng4"
+    },
+    {
+      "name": "with_payment_authorization_header",
+      "description": "A non-default credential header is inserted before opaque in the HMAC input",
+      "tags": ["happy-path", "optional-fields", "header-binding"],
+      "input": {
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
+        "realm": "api.example.com",
+        "method": "tempo",
+        "intent": "charge",
+        "request": {
+          "amount": "1000000"
+        },
+        "header": "Payment-Authorization"
+      },
+      "expected": "re8MIMJYpIJ0r_aiizscg6ghtipQM8IpOa_NtpwIU8E"
+    },
+    {
+      "name": "authorization_header_is_implicit_default",
+      "description": "An explicit Authorization header is normalized to the default and does not change the HMAC input",
+      "tags": ["happy-path", "optional-fields", "header-binding"],
+      "input": {
+        "secretKey": "test-vector-secret-minimum-32-byte-secret",
+        "realm": "api.example.com",
+        "method": "tempo",
+        "intent": "charge",
+        "request": {
+          "amount": "1000000"
+        },
+        "header": "Authorization"
+      },
+      "expected": "6QDs0BmhrI_v67iWeCMvGqQJEFQ6ErWKlk7zi5xL6t0"
     },
     {
       "name": "opaque_route_scope_binding",

--- a/conformance/vectors/www-authenticate.json
+++ b/conformance/vectors/www-authenticate.json
@@ -9,10 +9,10 @@
   "scenarios": [
     {
       "name": "payment_authorization_header",
-      "description": "Preserves the optional credential header supported by Rust SDK 0.12+",
+      "description": "Preserves the optional credential header supported after Rust SDK 0.12.0",
       "tags": ["happy-path", "optional-fields"],
       "adapters": ["rust"],
-      "sdkVersions": { "rust": ">=0.12.0" },
+      "sdkVersions": { "rust": ">0.12.0" },
       "object": {
         "id": "ch_header",
         "realm": "api.example.com",

--- a/conformance/vectors/www-authenticate.json
+++ b/conformance/vectors/www-authenticate.json
@@ -8,6 +8,23 @@
   },
   "scenarios": [
     {
+      "name": "payment_authorization_header",
+      "description": "Preserves the optional credential header supported by Rust SDK 0.12+",
+      "tags": ["happy-path", "optional-fields"],
+      "adapters": ["rust"],
+      "sdkVersions": { "rust": ">=0.12.0" },
+      "object": {
+        "id": "ch_header",
+        "realm": "api.example.com",
+        "method": "tempo",
+        "intent": "charge",
+        "request": {},
+        "header": "Payment-Authorization"
+      },
+      "wire": "Payment id=\"ch_header\", realm=\"api.example.com\", method=\"tempo\", intent=\"charge\", request=\"e30\", header=\"Payment-Authorization\"",
+      "tests": { "parse": true, "format": true, "roundtrip": true }
+    },
+    {
       "name": "basic_challenge",
       "description": "Minimal challenge with only required fields",
       "tags": ["happy-path", "required-fields"],


### PR DESCRIPTION
Support optional credential headers in Rust conformance while retaining compatibility with pinned mpp 0.11. Bind non-default credential headers into challenge IDs across adapters and gate Rust header vectors to supported releases.